### PR TITLE
[FIX] 인증게시물 - 숫자만 보이고 시간은 안 보이는 문제 해결

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/post/post/controller/ApiV1PostController.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/controller/ApiV1PostController.java
@@ -4,6 +4,7 @@ import com.dd.blog.domain.post.post.dto.PostPatchRequestDto;
 import com.dd.blog.domain.post.post.dto.PostRequestDto;
 import com.dd.blog.domain.post.post.dto.PostResponseDto;
 import com.dd.blog.domain.post.post.service.PostService;
+import com.dd.blog.global.security.SecurityUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -44,8 +46,9 @@ public class ApiV1PostController {
     @PostMapping("/category/{categoryId}")
     public ResponseEntity<PostResponseDto> createPost(
             @Parameter(description = "카테고리 ID", required = true) @PathVariable("categoryId") Long categoryId,
-            @Valid @RequestBody PostRequestDto postRequestDto){
-        PostResponseDto responseDto = postService.createPost(categoryId, postRequestDto);
+            @Valid @RequestBody PostRequestDto postRequestDto,
+            @AuthenticationPrincipal SecurityUser user){
+        PostResponseDto responseDto = postService.createPost(categoryId, user.getId(),postRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 

--- a/be/src/main/java/com/dd/blog/domain/post/post/dto/PostRequestDto.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/dto/PostRequestDto.java
@@ -14,9 +14,6 @@ public class PostRequestDto {
     @NotBlank(message = "내용 입력은 필수입니다.")
     private String content;
     private String imageUrl;
-
-    private Long userId;
-
     private String verificationImageUrl;
     private Integer detoxTime;
 }

--- a/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
@@ -54,8 +54,8 @@ public class PostService {
                 .imageUrl(postRequestDto.getImageUrl())
                 .category(category)
                 .user(user)
-                .detoxTime(postRequestDto.getDetoxTime()) //
-                .verificationImageUrl(postRequestDto.getVerificationImageUrl()) //
+                .detoxTime(postRequestDto.getDetoxTime()) // Integer: 디톡스 시간 (~h)
+                .verificationImageUrl(postRequestDto.getVerificationImageUrl()) // String: 인증 이미지 URL
                 .build();
 
         Post savedPost = postRepository.save(post);

--- a/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
@@ -54,6 +54,8 @@ public class PostService {
                 .imageUrl(postRequestDto.getImageUrl())
                 .category(category)
                 .user(user)
+                .detoxTime(postRequestDto.getDetoxTime()) //
+                .verificationImageUrl(postRequestDto.getVerificationImageUrl()) //
                 .build();
 
         Post savedPost = postRepository.save(post);

--- a/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
@@ -41,11 +41,11 @@ public class PostService {
     // CREATE
     // 게시글 CREATE
     @Transactional
-    public PostResponseDto createPost(Long categoryId, PostRequestDto postRequestDto){
+    public PostResponseDto createPost(Long categoryId, Long userId, PostRequestDto postRequestDto){
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
 
-        User user = userRepository.findById(postRequestDto.getUserId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
 
         Post post = Post.builder()

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fe",
       "version": "0.1.0",
       "dependencies": {
-        "@heroicons/react": "^2.2.0",
+        "@heroicons/react": "~2.2.0",
         "@tanstack/react-query": "^5.74.4",
         "@types/react-datepicker": "^6.2.0",
         "axios": "^1.8.4",

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fe",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@tanstack/react-query": "^5.74.4",
         "@types/react-datepicker": "^6.2.0",
         "axios": "^1.8.4",
@@ -281,6 +282,14 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/fe/package.json
+++ b/fe/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@tanstack/react-query": "^5.74.4",
     "@types/react-datepicker": "^6.2.0",
     "axios": "^1.8.4",

--- a/fe/package.json
+++ b/fe/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@heroicons/react": "^2.2.0",
+    "@heroicons/react": "~2.2.0",
     "@tanstack/react-query": "^5.74.4",
     "@types/react-datepicker": "^6.2.0",
     "axios": "^1.8.4",

--- a/fe/src/app/verification/write/page.tsx
+++ b/fe/src/app/verification/write/page.tsx
@@ -26,7 +26,7 @@ export default function VerificationWritePage({
   const router = useRouter();
   const { user } = useUser();
   const [category, setCategory] = useState('1'); // 인증=1, 정보공유=2, 자유=3
-  const [usageTime, setUsageTime] = useState<string>('');
+  const [detoxTime, setDetoxTime] = useState<number>(0);
   const [imageUrl, setImageUrl] = useState<string>('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -34,11 +34,10 @@ export default function VerificationWritePage({
     if (process.env.NODE_ENV === 'development') {
       console.log('Verification post data:', {
         imageUrl,
-        detoxTime: Number(usageTime),
-        content: usageTime,
+        detoxTime,
       });
     }
-  }, [imageUrl, usageTime]);
+  }, [imageUrl, detoxTime]);
 
   const handleCancel = () => {
     if (onClose) {
@@ -56,6 +55,15 @@ export default function VerificationWritePage({
     }
   };
 
+  const handleDetoxTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    // 빈 문자열이거나 음수인 경우 0으로 설정
+    const numValue = Math.max(0, Number(value));
+    if (!isNaN(numValue)) {
+      setDetoxTime(numValue);
+    }
+  };
+
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
@@ -67,8 +75,8 @@ export default function VerificationWritePage({
   };
 
   const handleSubmit = async () => {
-    if (!imageUrl || !usageTime) {
-      alert('휴대폰 이용시간 캡쳐와 이용시간을 모두 입력해야 합니다.');
+    if (!imageUrl || detoxTime <= 0) {
+      alert('휴대폰 이용시간 캡쳐와 디톡스 시간을 모두 입력해야 합니다.');
       return;
     }
 
@@ -76,9 +84,9 @@ export default function VerificationWritePage({
     const verificationPost: VerificationPost = {
       userId,
       title: '도파민 디톡스 인증',
-      content: usageTime,
+      content: detoxTime.toString(), // 기존 동작 유지를 위해 문자열로 변환
       imageUrl,
-      detoxTime: Number(usageTime),
+      detoxTime,
     };
 
     const res = await fetch(
@@ -176,8 +184,8 @@ export default function VerificationWritePage({
             <div className="flex items-center">
               <input
                 type="number"
-                value={usageTime}
-                onChange={(e) => setUsageTime(e.target.value)}
+                value={detoxTime}
+                onChange={handleDetoxTimeChange}
                 placeholder="0"
                 min="0"
                 className="w-16 text-right focus:outline-none text-black [caret-color:#F742CD]"

--- a/fe/src/app/verification/write/page.tsx
+++ b/fe/src/app/verification/write/page.tsx
@@ -66,6 +66,7 @@ export default function VerificationWritePage({
           title: '도파민 디톡스 인증',
           content: usageTime,
           imageUrl,
+          detoxTime: Number(usageTime),
         }),
         credentials: 'include',
       }

--- a/fe/src/components/Post.tsx
+++ b/fe/src/components/Post.tsx
@@ -57,6 +57,14 @@ export default function Post({
   }, [postId]);
 
   useEffect(() => {
+    console.log('Post verification data:', {
+      verificationImageUrl,
+      detoxTime,
+      content,
+    });
+  }, [verificationImageUrl, detoxTime, content]);
+
+  useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (postRef.current && !postRef.current.contains(event.target as Node)) {
         if (isEditingTitle) {
@@ -304,7 +312,9 @@ export default function Post({
               </div>
             ) : (
               <div className="flex items-start">
-                <p className="text-sm text-gray-700 flex-1">{content}</p>
+                <p className="text-sm text-gray-700 flex-1">
+                  {detoxTime > 0 ? `detoxed for ${detoxTime} hours` : content}
+                </p>
                 {user?.id === userId && (
                   <button
                     onClick={handleEditContent}

--- a/fe/src/components/Post.tsx
+++ b/fe/src/components/Post.tsx
@@ -313,7 +313,21 @@ export default function Post({
             ) : (
               <div className="flex items-start">
                 <p className="text-sm text-gray-700 flex-1">
-                  {detoxTime > 0 ? `detoxed for ${detoxTime} hours` : content}
+                  {(() => {
+                    if (
+                      typeof detoxTime === 'number' &&
+                      !isNaN(detoxTime) &&
+                      detoxTime > 0
+                    ) {
+                      return `detoxed for ${detoxTime} hours`;
+                    }
+
+                    if (!content) {
+                      return '';
+                    }
+
+                    return content;
+                  })()}
                 </p>
                 {user?.id === userId && (
                   <button


### PR DESCRIPTION
# 🔄 Fix PR

Fix PR입니다. 

</br>

> ### 📝 PR 제목 규칙
> **❝ [REFACTOR] 대상 - 개선내용 - (#이슈번호) ❞**
</br>*( 예: ❛ [REFACTOR] PostService - 중복 로직 제거 ❜ )* 

✒️커밋 메시지와 동일하게 쓰시면 됩니다.

</br></br>
---

### ✏️ 여기부터 써주시면 됩니다.
.
</br>.

### 1️⃣관련 이슈
이슈 링크 달아주세요. (필요하다면) 

🔗
- #90 

.   
</br>.

### 2️⃣ 버그 발생 이유
✒️

- 전:  detoxTime 값을 저장하지도, 전달하지도 않았고, 대신 content에 "2"를 넣어 UI 착시가 있었던 상태
   - **be** 
      - `PostService.createPost()` - PostRequestDto에는 값이 있었지만, Post 엔티티로 빌드할 때 그 필드들을 반영하지 않았기 때문에
         - 👉 `detoxTime = null`로 저장됨 → DB에서는 0으로 보여짐
   - **fe**  
      - `usageTime`이라는 값을 content 필드에 넣고 있었기 때문에, UI에는 숫자 2처럼 보여졌지만, 
         - 실제 `detoxTime`은 아예 전달조차 안 된 상태

- `userId`를 프론트에서 넘기지 않고, 백엔드가 인증 객체(@AuthenticationPrincipal)를 통해 직접 추출하도록 구조 전환
   - **fe** 
      -  VerificationPost 타입에서 `userId` 제거
      -  `handleSubmit()` 내 body 구성 시 `userId` 제거
   - **be**
      - PostRequestDto에서 `userId` 필드 제거
      - `PostService.createPost(Long categoryId, PostRequestDto dto)` -> `PostService.createPost(Long categoryId, Long userId, PostRequestDto dto)`
      - `ApiV1PostController` : 
         

> ```
> return ResponseEntity.status(HttpStatus.CREATED)
>         .body(postService.createPost(categoryId, user.getId(), dto));
> ```




