### PR TITLE
[FEAT/FIX] (FE)댓글 - UI 구현 + (BE)댓글 수·디톡스 시간 - 출력 버그 수정

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/post/post/dto/PostResponseDto.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/dto/PostResponseDto.java
@@ -19,6 +19,7 @@ public class PostResponseDto {
     private String title;
     private String content;
     private String imageUrl;
+    private int viewCount;
     private int likeCount;
     private int commentCount;
 
@@ -37,8 +38,9 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .imageUrl(post.getImageUrl())
-                .commentCount(post.getComments() != null ? post.getComments().size() : 0) // null 체크
+                .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())
+                .commentCount(post.getComments() != null ? post.getComments().size() : 0) // null 체크
                 .verificationImageUrl(post.getVerificationImageUrl())
                 .detoxTime(post.getDetoxTime())
                 .createdAt(post.getCreatedAt())

--- a/be/src/main/java/com/dd/blog/domain/post/post/dto/PostResponseDto.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/dto/PostResponseDto.java
@@ -19,8 +19,8 @@ public class PostResponseDto {
     private String title;
     private String content;
     private String imageUrl;
-    private int viewCount;
     private int likeCount;
+    private int commentCount;
 
     private String verificationImageUrl;
     private Integer detoxTime;
@@ -37,7 +37,7 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .imageUrl(post.getImageUrl())
-                .viewCount(post.getViewCount())
+                .commentCount(post.getComments().size())
                 .likeCount(post.getLikeCount())
                 .verificationImageUrl(post.getVerificationImageUrl())
                 .detoxTime(post.getDetoxTime())

--- a/be/src/main/java/com/dd/blog/domain/post/post/dto/PostResponseDto.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/dto/PostResponseDto.java
@@ -37,7 +37,7 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .imageUrl(post.getImageUrl())
-                .commentCount(post.getComments().size())
+                .commentCount(post.getComments() != null ? post.getComments().size() : 0) // null 체크
                 .likeCount(post.getLikeCount())
                 .verificationImageUrl(post.getVerificationImageUrl())
                 .detoxTime(post.getDetoxTime())

--- a/be/src/main/java/com/dd/blog/domain/post/post/entity/Post.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/entity/Post.java
@@ -2,6 +2,7 @@ package com.dd.blog.domain.post.post.entity;
 
 import com.dd.blog.domain.post.category.entity.Category;
 import com.dd.blog.domain.user.user.entity.User;
+import com.dd.blog.domain.post.comment.entity.Comment;
 import com.dd.blog.global.jpa.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList; // for 댓글 list
+import java.util.List;
 
 @Entity
 @Getter
@@ -36,8 +40,6 @@ public class Post extends BaseEntity {
     @Column(name = "image_url", nullable = false, length=100)
     private String imageUrl;
 
-    @Column(name="view_count")
-    private int viewCount;
 
     @Column(name="like_count")
     private int likeCount;
@@ -48,6 +50,10 @@ public class Post extends BaseEntity {
 
     @Column(name = "detox_time")
     private Integer detoxTime;
+
+    // 게시글 - 댓글 관계 JPA 상에서 연결
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     // 게시글 수정 메서드
     public void update(String title, String content, String imageUrl) {

--- a/be/src/main/java/com/dd/blog/domain/post/post/entity/Post.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/entity/Post.java
@@ -40,6 +40,9 @@ public class Post extends BaseEntity {
     @Column(name = "image_url", nullable = false, length=100)
     private String imageUrl;
 
+    // 인기게시글 TOP5 위해 다시 추가
+    @Column(name = "view_count")
+    private int viewCount = 0;
 
     @Column(name="like_count")
     private int likeCount;
@@ -73,4 +76,10 @@ public class Post extends BaseEntity {
             this.likeCount--;
         }
     }
+
+    // viewCount 메서드
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
 }

--- a/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
@@ -56,6 +56,7 @@ public class PostService {
                 .user(user)
                 .detoxTime(postRequestDto.getDetoxTime()) // Integer: 디톡스 시간 (~h)
                 .verificationImageUrl(postRequestDto.getVerificationImageUrl()) // String: 인증 이미지 URL
+                .viewCount(0) // 핫게시물 TOP5 위해 재추가
                 .build();
 
         Post savedPost = postRepository.save(post);
@@ -142,6 +143,8 @@ public class PostService {
     public PostResponseDto getPostById(Long postId){
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+        // 조회수 증가
+        post.increaseViewCount();
         return PostResponseDto.fromEntity(post);
     }
 

--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -599,6 +599,42 @@ export default function Home() {
     }
   };
 
+  // 댓글 수 업데이트 핸들러
+  const handleCommentUpdate = async (postId: number, count: number) => {
+    // React Query 캐시 업데이트
+    queryClient.setQueryData<{ pages: PostsResponse[] }>(
+      ['posts', selectedBoard, sortType, searchType, searchKeyword],
+      (oldData) => {
+        if (!oldData) return oldData;
+
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            content: page.content.map((post) => {
+              if (post.postId === postId) {
+                return {
+                  ...post,
+                  commentCount: count, // 실제 댓글 수 사용
+                };
+              }
+              return post;
+            }),
+          })),
+        };
+      }
+    );
+  };
+
+  // 좋아요/좋아요 취소 핸들러를 useCallback으로 메모이제이션
+  const memoizedHandleLike = useCallback((postId: number) => {
+    handleLike(postId);
+  }, []);
+
+  const memoizedHandleUnlike = useCallback((postId: number) => {
+    handleUnlike(postId);
+  }, []);
+
   const posts = data?.pages.flatMap((page) => page.content) || [];
 
   return (
@@ -982,11 +1018,13 @@ export default function Home() {
                         createdAt={post.createdAt || ''}
                         updatedAt={post.updatedAt || ''}
                         onUpdate={() => refetch()}
-                        onLike={() => handleLike(post.postId)}
-                        onUnlike={() => handleUnlike(post.postId)}
+                        onLike={memoizedHandleLike}
+                        onUnlike={memoizedHandleUnlike}
                         isLiked={post.likedByCurrentUser}
                         onDelete={handleDelete}
-                        //userProfileImage={post.userProfileImage}
+                        onCommentUpdate={(count) =>
+                          handleCommentUpdate(post.postId, count)
+                        }
                       />
                     </div>
                   );

--- a/fe/src/components/CommentModal.tsx
+++ b/fe/src/components/CommentModal.tsx
@@ -1,0 +1,484 @@
+import { useState, useEffect, useRef } from 'react';
+import { useUser } from '@/contexts/UserContext';
+import { Comment, CommentRequestDto } from '@/types/comment';
+import Image from 'next/image';
+
+interface CommentModalProps {
+  postId: number;
+  onClose: () => void;
+  postImage?: string;
+  postContent?: string;
+  userNickname?: string;
+  createdAt?: string;
+  isOwnPost?: boolean;
+  onUpdate?: (count: number) => void;
+  onImageUpdate?: (newImage: File) => void;
+}
+
+export default function CommentModal({
+  postId,
+  onClose,
+  postImage,
+  postContent,
+  userNickname,
+  createdAt,
+  isOwnPost,
+  onUpdate,
+  onImageUpdate,
+}: CommentModalProps) {
+  const { user } = useUser();
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [newComment, setNewComment] = useState('');
+  const [replyTo, setReplyTo] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showEmoji, setShowEmoji] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [isEditingContent, setIsEditingContent] = useState(false);
+  const [editedTitle, setEditedTitle] = useState(postContent || '');
+  const [editedContent, setEditedContent] = useState(postContent || '');
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 댓글 목록 불러오기
+  const fetchComments = async () => {
+    try {
+      const response = await fetch(
+        `http://localhost:8090/api/v1/comments/${postId}`,
+        {
+          credentials: 'include',
+        }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setComments(data);
+        if (onUpdate) onUpdate(data.length);
+      }
+    } catch (error) {
+      console.error('댓글 로드 중 오류:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchComments();
+  }, [postId]);
+
+  // 댓글 작성
+  const handleSubmitComment = async () => {
+    if (!newComment.trim()) return;
+
+    const commentData: CommentRequestDto = {
+      content: newComment.trim(),
+      parentId: replyTo,
+    };
+
+    try {
+      setIsLoading(true);
+      const response = await fetch(
+        `http://localhost:8090/api/v1/comments/${postId}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify(commentData),
+        }
+      );
+
+      if (response.ok) {
+        setNewComment('');
+        setReplyTo(null);
+        await fetchComments();
+      }
+    } catch (error) {
+      console.error('댓글 작성 중 오류:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 댓글 삭제
+  const handleDeleteComment = async (commentId: number) => {
+    try {
+      const response = await fetch(
+        `http://localhost:8090/api/v1/comments/${commentId}`,
+        {
+          method: 'DELETE',
+          credentials: 'include',
+        }
+      );
+
+      if (response.ok) {
+        await fetchComments();
+      }
+    } catch (error) {
+      console.error('댓글 삭제 중 오류:', error);
+    }
+  };
+
+  // 시간 경과 표시 함수 수정
+  const getTimeAgo = (dateString: string | undefined) => {
+    if (!dateString) return '';
+
+    const date = new Date(dateString);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+
+    const minutes = Math.floor(diff / 60000);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (days > 0) return `${days}일`;
+    if (hours > 0) return `${hours}시간`;
+    if (minutes > 0) return `${minutes}분`;
+    return '방금';
+  };
+
+  // 게시글 수정 함수
+  const handleSaveContent = async () => {
+    if (!postId) {
+      setError('게시글 ID가 없습니다.');
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `http://localhost:8090/api/v1/posts/${postId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify({
+            content: editedContent,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('게시글 수정에 실패했습니다.');
+      }
+
+      setIsEditingContent(false);
+      if (onUpdate) {
+        onUpdate(comments.length);
+      }
+    } catch (error) {
+      console.error('Error updating post:', error);
+      setError(
+        error instanceof Error
+          ? error.message
+          : '게시글 수정 중 오류가 발생했습니다.'
+      );
+    }
+  };
+
+  // 이미지 업데이트 핸들러
+  const handleImageClick = () => {
+    if (isOwnPost && fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && onImageUpdate) {
+      onImageUpdate(file);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50"
+        onClick={onClose}
+      />
+      <div className="relative bg-white w-full max-w-3xl h-[80vh] max-h-[600px] flex rounded-md overflow-hidden">
+        {/* 왼쪽: 게시글 이미지 */}
+        {postImage && (
+          <div className="w-[50%] bg-black flex items-center justify-center relative group">
+            <Image
+              src={postImage}
+              alt="게시글 이미지"
+              width={600}
+              height={450}
+              className="max-h-full max-w-full object-contain"
+            />
+            {isOwnPost && (
+              <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-opacity flex items-center justify-center">
+                <button
+                  onClick={handleImageClick}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity text-white hover:text-gray-200"
+                >
+                  <svg
+                    className="w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            )}
+            <input
+              type="file"
+              ref={fileInputRef}
+              className="hidden"
+              accept="image/*"
+              onChange={handleImageChange}
+            />
+          </div>
+        )}
+
+        {/* 오른쪽: 댓글 영역 */}
+        <div
+          className={`${
+            postImage ? 'w-[50%]' : 'w-full'
+          } flex flex-col bg-white`}
+        >
+          {/* 헤더 */}
+          <div className="flex items-center p-3 border-b">
+            <div className="w-8 h-8 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center">
+              <svg
+                className="w-4 h-4 text-gray-500"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+            <span className="ml-3 font-bold text-[14px] text-black hover:text-gray-900">
+              {userNickname}
+            </span>
+          </div>
+
+          {/* 댓글 목록 */}
+          <div className="flex-1 overflow-y-auto">
+            {/* 원글 내용 */}
+            <div className="p-3 border-b">
+              <div className="flex space-x-3">
+                <div className="flex-shrink-0">
+                  <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center">
+                    <svg
+                      className="w-4 h-4 text-gray-500"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div className="flex-1 group">
+                  <div className="flex items-baseline">
+                    <span className="font-bold text-[14px] text-black hover:text-gray-900">
+                      {userNickname}
+                    </span>
+                    {isOwnPost && !isEditingContent ? (
+                      <div className="relative flex-1">
+                        <p className="ml-2 text-[14px] text-gray-900">
+                          {postContent}
+                        </p>
+                        <button
+                          onClick={() => setIsEditingContent(true)}
+                          className="absolute right-0 top-0 opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-gray-700"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    ) : isEditingContent ? (
+                      <div className="flex-1 ml-2">
+                        <textarea
+                          value={editedContent}
+                          onChange={(e) => setEditedContent(e.target.value)}
+                          className="w-full text-[14px] text-black border-none focus:ring-0 focus:outline-none resize-none bg-transparent [caret-color:#F742CD]"
+                          rows={3}
+                          autoFocus
+                        />
+                        <div className="flex justify-end space-x-2 mt-2">
+                          <button
+                            onClick={() => {
+                              setIsEditingContent(false);
+                              setEditedContent(postContent || '');
+                            }}
+                            className="text-sm text-gray-500 hover:text-gray-700"
+                          >
+                            취소
+                          </button>
+                          <button
+                            onClick={handleSaveContent}
+                            className="text-sm text-[#F742CD] hover:text-pink-600"
+                          >
+                            완료
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <span className="ml-2 text-[14px] text-gray-900">
+                        {postContent}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-400">
+                    {getTimeAgo(createdAt)} 전
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 댓글 목록 */}
+            <div className="px-3 py-2 space-y-4">
+              {comments.length === 0 ? (
+                <div className="text-center text-gray-500 py-8">
+                  <p className="text-sm">아직 댓글이 없습니다.</p>
+                  <p className="text-xs mt-1">첫 댓글을 작성해보세요!</p>
+                </div>
+              ) : (
+                comments.map((comment) => (
+                  <div
+                    key={comment.id}
+                    className={`flex space-x-3 ${
+                      comment.parentId ? 'ml-8' : ''
+                    }`}
+                  >
+                    <div className="flex-shrink-0">
+                      <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center">
+                        <svg
+                          className="w-4 h-4 text-gray-500"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <span className="font-bold text-[14px] text-black hover:text-gray-900">
+                            {comment.userNickname}
+                          </span>
+                          <span className="ml-2 text-[14px] text-gray-900">
+                            {comment.content}
+                          </span>
+                        </div>
+                        {user?.id === comment.userId && (
+                          <button
+                            onClick={() => handleDeleteComment(comment.id)}
+                            className="text-xs text-gray-400 hover:text-red-500 ml-2"
+                          >
+                            삭제
+                          </button>
+                        )}
+                      </div>
+                      <div className="flex items-center mt-1 space-x-3">
+                        <span className="text-xs text-gray-400">
+                          {getTimeAgo(comment.createdAt)} 전
+                        </span>
+                        <button
+                          onClick={() => setReplyTo(comment.id)}
+                          className="text-xs font-semibold text-gray-400 hover:text-gray-600"
+                        >
+                          답글 달기
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* 댓글 입력 영역 */}
+          <div className="border-t px-3 py-2">
+            {replyTo && (
+              <div className="flex items-center justify-between mb-2 bg-gray-50 p-2 rounded-sm text-xs">
+                <span className="text-gray-600">답글 작성 중</span>
+                <button
+                  onClick={() => setReplyTo(null)}
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  취소
+                </button>
+              </div>
+            )}
+            <div className="flex items-center space-x-2">
+              <button
+                onClick={() => setShowEmoji(!showEmoji)}
+                className="text-gray-400 hover:text-gray-600 p-1 rounded-md"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </button>
+              <input
+                type="text"
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="댓글 달기..."
+                className="flex-1 text-sm text-black border-none focus:ring-0 focus:outline-none min-h-[36px] py-1 placeholder-gray-400 [caret-color:#F742CD] rounded-sm"
+                onKeyPress={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSubmitComment();
+                  }
+                }}
+              />
+              <button
+                onClick={handleSubmitComment}
+                disabled={isLoading || !newComment.trim()}
+                className={`text-sm font-semibold px-2 rounded-sm ${
+                  isLoading || !newComment.trim()
+                    ? 'text-gray-300 cursor-not-allowed'
+                    : 'text-[#F742CD] hover:text-pink-600'
+                }`}
+              >
+                게시
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/components/Post.tsx
+++ b/fe/src/components/Post.tsx
@@ -11,7 +11,6 @@ export interface PostProps {
   title: string;
   content: string;
   imageUrl: string;
-  viewCount: number;
   likeCount: number;
   commentCount: number;
   verificationImageUrl: string;
@@ -34,7 +33,6 @@ export default function Post({
   title,
   content,
   imageUrl,
-  viewCount,
   likeCount,
   commentCount,
   verificationImageUrl,
@@ -295,6 +293,9 @@ export default function Post({
               </Link>
               <span className="text-xs text-gray-500">
                 • {getTimeAgo(createdAt)}
+                {updatedAt && updatedAt !== createdAt && (
+                  <span className="ml-1">• 수정됨</span>
+                )}
               </span>
               <span className="ml-1 text-xs text-green-500">
                 <svg
@@ -581,6 +582,7 @@ export default function Post({
           createdAt={createdAt}
           isOwnPost={user?.id === userId}
           onUpdate={handleCommentCountUpdate}
+          detoxTime={detoxTime}
           onImageUpdate={async (newImage) => {
             const formData = new FormData();
             formData.append('image', newImage);

--- a/fe/src/components/Post.tsx
+++ b/fe/src/components/Post.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { useUser } from '@/contexts/UserContext';
 import Link from 'next/link';
+import CommentModal from './CommentModal';
 
 export interface PostProps {
   postId: number;
@@ -18,10 +19,11 @@ export interface PostProps {
   createdAt: string;
   updatedAt: string;
   onUpdate?: () => void;
-  onLike: () => void;
-  onUnlike: () => void;
+  onLike: (postId: number) => void;
+  onUnlike: (postId: number) => void;
   isLiked?: boolean;
   onDelete?: (postId: number) => void;
+  onCommentUpdate?: (count: number) => void;
   userProfileImage?: string | null;
 }
 
@@ -44,6 +46,7 @@ export default function Post({
   onUnlike,
   isLiked,
   onDelete,
+  onCommentUpdate,
   userProfileImage,
 }: PostProps) {
   const { user } = useUser();
@@ -53,6 +56,7 @@ export default function Post({
   const [editedContent, setEditedContent] = useState(content);
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showCommentModal, setShowCommentModal] = useState(false);
   const postRef = useRef<HTMLDivElement>(null);
 
   // 프로필 이미지 URL 가져오기
@@ -233,6 +237,21 @@ export default function Post({
     if (hours > 0) return `${hours}시간 전`;
     if (minutes > 0) return `${minutes}분 전`;
     return '방금 전';
+  };
+
+  // 댓글 모달이 닫힐 때 댓글 수 업데이트
+  const handleCommentModalClose = () => {
+    setShowCommentModal(false);
+  };
+
+  const handleCommentCountUpdate = (count: number) => {
+    if (onCommentUpdate) {
+      onCommentUpdate(count);
+    }
+  };
+
+  const handleImageClick = () => {
+    // Implementation of handleImageClick
   };
 
   return (
@@ -423,7 +442,7 @@ export default function Post({
       {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
 
       {imageUrl && (
-        <div className="rounded-lg overflow-hidden mb-3 mt-3">
+        <div className="rounded-lg overflow-hidden mb-3 mt-3 relative group">
           <Image
             src={imageUrl}
             alt="게시글 이미지"
@@ -431,18 +450,39 @@ export default function Post({
             height={300}
             className="w-full h-auto object-cover"
           />
+          {user?.id === userId && (
+            <button
+              onClick={handleImageClick}
+              className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity text-white hover:text-gray-200 bg-black bg-opacity-50 rounded-full p-1.5"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          )}
         </div>
       )}
 
       <div className="mt-4 flex items-center gap-4">
         <button
-          onClick={() => (isLiked ? onUnlike() : onLike())}
-          className="flex items-center gap-1"
+          onClick={() => (isLiked ? onUnlike(postId) : onLike(postId))}
+          className={`flex items-center gap-1 group ${
+            isLiked ? 'text-pink-500' : 'text-gray-400 hover:text-pink-500'
+          } transition-colors`}
         >
           {isLiked ? (
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5 text-pink-500"
+              className="h-5 w-5"
               viewBox="0 0 20 20"
               fill="currentColor"
             >
@@ -455,7 +495,7 @@ export default function Post({
           ) : (
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5 text-gray-400"
+              className="h-5 w-5"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -468,13 +508,16 @@ export default function Post({
               />
             </svg>
           )}
-          <span className="text-sm text-gray-500">{likeCount}</span>
+          <span className="text-sm">{likeCount}</span>
         </button>
 
-        <div className="flex items-center gap-1">
+        <button
+          onClick={() => setShowCommentModal(true)}
+          className="flex items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors"
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="h-5 w-5 text-gray-400"
+            className="h-5 w-5"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -482,8 +525,8 @@ export default function Post({
           >
             <path d="M8 12h.01M12 12h.01M16 12h.01M3 12c0 4.97 4.03 9 9 9a9.863 9.863 0 004.255-.949L21 21l-1.395-4.72C20.488 15.042 21 13.574 21 12c0-4.97-4.03-9-9-9s-9 4.03-9 9z" />
           </svg>
-          <span className="text-sm text-gray-500">{commentCount}</span>
-        </div>
+          <span className="text-sm">{commentCount}</span>
+        </button>
       </div>
 
       {/* 삭제 확인 모달 */}
@@ -525,6 +568,46 @@ export default function Post({
             </div>
           </div>
         </div>
+      )}
+
+      {/* 댓글 모달 */}
+      {showCommentModal && (
+        <CommentModal
+          postId={postId}
+          onClose={handleCommentModalClose}
+          postImage={imageUrl}
+          postContent={content}
+          userNickname={userNickname}
+          createdAt={createdAt}
+          isOwnPost={user?.id === userId}
+          onUpdate={handleCommentCountUpdate}
+          onImageUpdate={async (newImage) => {
+            const formData = new FormData();
+            formData.append('image', newImage);
+
+            try {
+              const response = await fetch(
+                `http://localhost:8090/api/v1/posts/${postId}/image`,
+                {
+                  method: 'PATCH',
+                  credentials: 'include',
+                  body: formData,
+                }
+              );
+
+              if (!response.ok) {
+                throw new Error('이미지 업데이트 실패');
+              }
+
+              if (onUpdate) {
+                onUpdate();
+              }
+            } catch (error) {
+              console.error('이미지 업데이트 중 오류:', error);
+              alert('이미지 업데이트에 실패했습니다.');
+            }
+          }}
+        />
       )}
     </div>
   );

--- a/fe/src/types/comment.ts
+++ b/fe/src/types/comment.ts
@@ -1,0 +1,32 @@
+export interface Comment {
+  id: number;
+  postId: number;
+  userId: number;
+  userNickname: string;
+  content: string;
+  parentId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommentRequestDto {
+  content: string;
+  parentId?: number | null;
+}
+
+export interface CommentResponseDto {
+  id: number;
+  postId: number;
+  userId: number;
+  userNickname: string;
+  content: string;
+  parentId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommentUpdateResponseDto {
+  id: number;
+  content: string;
+  updatedAt: string;
+}

--- a/fe/src/types/comment.ts
+++ b/fe/src/types/comment.ts
@@ -7,6 +7,7 @@ export interface Comment {
   parentId: number | null;
   createdAt: string;
   updatedAt: string;
+  detoxTime?: number;
 }
 
 export interface CommentRequestDto {


### PR DESCRIPTION
---
name: 🧠 Feature
about: 새로운 기능을 추가하는 PR 템플릿입니다.
title: "[FEAT] 대상 - 추가 기능 - #이슈번호"
labels: 🧠 merge feature

---
</br>

# 🧠 Feature PR

새로운 기능을 추가하는 PR입니다. 

</br>

> ### 📝 PR 제목 규칙
> **❝ [FEAT] 대상 - 추가 기능 - #이슈번호 ❞**
</br>*( 예: ❛ [FEAT] PostService - 게시글 생성 기능 추가 - #13 ❜ )* 

✒️커밋 메시지와 동일하게 쓰시면 됩니다.

</br></br>
---

### ✏️ 여기부터 써주시면 됩니다.
.
</br>.

### 1️⃣관련 이슈
이슈 링크 달아주세요. 

🔗
- #94 
</br></br>
.
### 2️⃣작업 내용
어떤 기능을 구현했는지 간단히 설명

✒️
**FE**
- **댓글대댓글 - UI**
   - 게시글 작성 페이지처럼 모달 형식으로 구현
   - 댓글 수 중복 증가 버그
      - 문제: 댓글 모달 열기만 해도 `onUpdate()`가 호출되어 댓글 수(`commentCount`)가 매번 +1씩 증가했음.
   - 원인: 댓글 목록 조회 후 `onUpdate(data.length)` 호출 로직이 렌더링마다 반복 실행됨.
   - 해결: `useEffect` 내부 `fetchComments()`에서 의도적 업데이트만 반영하도록 조정하여 중복 호출 방지
- **댓글 모달 내 `detoxTime` "2"만 뜨던 현상**
   - 문제: 댓글 작성자가 `detoxTime`을 가지고 있어도, `comment.content` 대신 `comment.detoxTime`만 출력되어 "2"만 보임.
   - 원인: `detoxTime` 우선 조건문 로직에서 실제 content 출력 로직이 막힘.
   - 해결: `detoxTime` 존재 시에는 "detoxed for {X} hours"로 출력, 없을 경우 `comment.content` 출력되도록 조건 분기 개선.


**BE** 
- **PostResponseDto, Post 엔티티 - 댓글 수 `commentCount` 필드 추가**
- **게시글 조회수(`viewCount`) 로직 구현**
   - Post 엔티티에 존재하던 `viewCount` 필드를 실제로 활용하도록 로직 추가
   - 상세 조회(GET /api/v1/posts/{postId}) 시 `viewCount`가 1씩 증가하도록 구현
   - `PostService.getPostById()` 내부에서 `post.increaseViewCount()` 호출 및 저장 처리 추가
   - **조회수는 인기글 정렬 보조 기준으로만 사용하며, 일반 게시글 리스트에는 출력하지 않음**
- **게시글 등록 실패(NPE) 버그 수정**
   - 게시글 등록 시 `PostResponseDto.fromEntity()` 내부에서 `post.getComments().size()` 호출 중 NPE 발생
   - 원인은 `post.getComments()`가 null일 수 있는데 null 체크 없이 `.size()` 호출함
   - 해당 부분을 `post.getComments() != null ? post.getComments().size() : 0` 형태로 null-safe하게 수정하여 해결
</br></br>

.
### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [ ] 로컬에서 테스트 완료 🧪🫧

</br>어떻게 테스트했는지 (경로, 사용 조건 등)

✒️
- Swagger
- ui
</br></br>



