### PR TITLE
[FEAT] 관리자 승인 페이지 및 백엔드 연동 완료

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/admin/controller/AdminDashboardController.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/controller/AdminDashboardController.java
@@ -1,0 +1,38 @@
+package com.dd.blog.domain.admin.controller;
+
+import com.dd.blog.domain.admin.dto.AdminDashboardStatsDto;
+import com.dd.blog.domain.admin.service.AdminDashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/dashboard")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "AdminDashboard API", description = "관리자용 메인 페이지용 주요 통계 API")
+public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+
+    @Operation(summary = "관리자용 대시보드 통계 조회", description = "대시보드에 표시될 주요 통계 정보(총 회원 수, 대기 중인 인증 수 등)를 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "통계 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자 (관리자 아님)")
+    })
+    @GetMapping("/stats")
+    public ResponseEntity<AdminDashboardStatsDto> getDashboardStats() {
+        AdminDashboardStatsDto statsDto = adminDashboardService.getDashboardStats();
+        return ResponseEntity.ok(statsDto);
+    }
+
+}

--- a/be/src/main/java/com/dd/blog/domain/admin/controller/AdminVerificationV1Controller.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/controller/AdminVerificationV1Controller.java
@@ -2,6 +2,7 @@ package com.dd.blog.domain.admin.controller;
 
 import com.dd.blog.domain.admin.dto.VerificationStatusUpdateDto;
 import com.dd.blog.domain.admin.service.AdminVerificationService;
+import com.dd.blog.domain.post.verification.dto.VerificationResponseDto;
 import com.dd.blog.domain.post.verification.entity.Verification;
 import com.dd.blog.domain.post.verification.entity.VerificationStatus;
 import jakarta.validation.Valid;
@@ -39,8 +40,8 @@ public class AdminVerificationV1Controller {
 
     // PENDING 상태인 인증 요청 목록을 페이징하여 조회
     @GetMapping
-    public ResponseEntity<Page<Verification>> getPendingVerifications(Pageable pageable) {
-        Page<Verification> pendingVerifications = adminVerificationService.getPendingVerification(pageable);
+    public ResponseEntity<Page<VerificationResponseDto>> getPendingVerifications(Pageable pageable) {
+        Page<VerificationResponseDto> pendingVerifications = adminVerificationService.getPendingVerification(pageable);
         return ResponseEntity.ok(pendingVerifications);
     }
 

--- a/be/src/main/java/com/dd/blog/domain/admin/dto/AdminDashboardStatsDto.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/dto/AdminDashboardStatsDto.java
@@ -1,0 +1,18 @@
+package com.dd.blog.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminDashboardStatsDto {
+
+    private long totalUsers;
+    private long usersJoinedToday;
+
+    private long pendingVerifications;
+    private long verificationsProcessedToday;
+
+    private long totalPosts;
+    private long postsCreatedToday;
+}

--- a/be/src/main/java/com/dd/blog/domain/admin/service/AdminDashboardService.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/service/AdminDashboardService.java
@@ -1,0 +1,56 @@
+package com.dd.blog.domain.admin.service;
+
+import com.dd.blog.domain.admin.dto.AdminDashboardStatsDto;
+import com.dd.blog.domain.post.post.repository.PostRepository;
+import com.dd.blog.domain.post.verification.entity.VerificationStatus;
+import com.dd.blog.domain.post.verification.repository.VerificationRepository;
+import com.dd.blog.domain.user.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDashboardService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final VerificationRepository verificationRepository;
+
+    @Transactional(readOnly = true)
+    public AdminDashboardStatsDto getDashboardStats() {
+        // 오늘 날짜범위 계산
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+
+        // 각 통계 계산
+        long totalUsers = userRepository.count();
+        long pendingVerifications = verificationRepository.countByStatus(VerificationStatus.PENDING); // 리포지토리 메소드 필요!
+        long verificationsProcessedToday = verificationRepository.countByStatusInAndUpdatedAtBetween(
+                List.of(VerificationStatus.APPROVED, VerificationStatus.REJECTED), // 처리된 상태 목록
+                startOfDay,
+                endOfDay
+        );
+
+        long usersJoinedToday = userRepository.countByCreatedAtBetween(startOfDay, endOfDay); // 리포지토리 메소드 필요!
+        long postsCreatedToday = postRepository.countByCreatedAtBetween(startOfDay, endOfDay); // 리포지토리 메소드 필요!
+        long totalPosts = postRepository.count();
+
+        return AdminDashboardStatsDto.builder()
+                .totalUsers(totalUsers)
+                .pendingVerifications(pendingVerifications)
+                .verificationsProcessedToday(verificationsProcessedToday)
+                .usersJoinedToday(usersJoinedToday)
+                .postsCreatedToday(postsCreatedToday)
+                .totalPosts(totalPosts)
+                .build();
+
+    }
+
+
+}

--- a/be/src/main/java/com/dd/blog/domain/admin/service/AdminVerificationService.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/service/AdminVerificationService.java
@@ -1,5 +1,6 @@
 package com.dd.blog.domain.admin.service;
 import com.dd.blog.domain.point.service.PointService;
+import com.dd.blog.domain.post.verification.dto.VerificationResponseDto;
 import com.dd.blog.domain.post.verification.entity.Verification;
 import com.dd.blog.domain.post.verification.entity.VerificationStatus;
 import com.dd.blog.domain.post.verification.repository.VerificationRepository;
@@ -52,8 +53,12 @@ public class AdminVerificationService {
 
     // PENDING 상태 인증 요청 목록 조회 메서드 구현
     @Transactional(readOnly = true)
-    public Page<Verification> getPendingVerification(Pageable pageable) {
-        return verificationRepository.findByStatusOrderByIdAsc(VerificationStatus.PENDING, pageable);
+    public Page<VerificationResponseDto> getPendingVerification(Pageable pageable) {
+
+        Page<Verification> verificationPage = verificationRepository.findByStatusOrderByIdAsc(VerificationStatus.PENDING, pageable);
+        Page<VerificationResponseDto> dtoPage = verificationPage.map(VerificationResponseDto::fromEntity);
+
+        return dtoPage;
     }
 
 

--- a/be/src/main/java/com/dd/blog/domain/post/post/repository/PostRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/repository/PostRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -24,6 +25,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 카테고리 ID로 게시글 페이지 조회
     Page<Post> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
+
+    // 오늘 생성된 게시글 개수 반환
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
     // 사용자 정의 JPQL 쿼리: 검색 타입(type)이 'title'이면 제목에서, 'writer'면 작성자 닉네임에서 keyword를 LIKE 검색
     @Query("SELECT p FROM Post p " +

--- a/be/src/main/java/com/dd/blog/domain/post/verification/dto/VerificationRequestDto.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/dto/VerificationRequestDto.java
@@ -2,11 +2,13 @@ package com.dd.blog.domain.post.verification.dto;
 
 import com.dd.blog.domain.post.verification.entity.VerificationStatus;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class VerificationRequestDto {
     // 인증 요청 게시글 ID, 사용자 ID
     private Long postId;

--- a/be/src/main/java/com/dd/blog/domain/post/verification/dto/VerificationResponseDto.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/dto/VerificationResponseDto.java
@@ -1,8 +1,13 @@
 package com.dd.blog.domain.post.verification.dto;
 
+import com.dd.blog.domain.post.post.entity.Post;
+import com.dd.blog.domain.post.verification.entity.Verification;
 import com.dd.blog.domain.post.verification.entity.VerificationStatus;
+import com.dd.blog.domain.user.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -12,4 +17,35 @@ public class VerificationResponseDto {
     private Long userId;
     private VerificationStatus status;
     private int detoxTime;
+
+    // 관리자 목록 화면
+    private String userNickname;
+    private String verificationImageUrl;
+    private LocalDateTime createdAt;
+
+
+    public static VerificationResponseDto fromEntity(Verification verification) {
+        if(verification == null)
+            return null;
+
+        User user = verification.getUser();
+        Post post = verification.getPost();
+
+        String nickname = (user != null) ? user.getNickname() : null;
+        String imageUrl = (post != null) ? post.getVerificationImageUrl() : null;
+        Long postId = (post != null) ? post.getId() : null;
+        Long userId = (user != null) ? user.getId() : null;
+
+        return VerificationResponseDto.builder()
+                .verificationId(verification.getId())
+                .postId(postId)
+                .userId(userId)
+                .status(verification.getStatus())
+                .detoxTime(verification.getDetoxTime())
+                .userNickname(nickname)
+                .verificationImageUrl(imageUrl)
+                .createdAt(verification.getCreatedAt())
+                .build();
+    }
+
 }

--- a/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
@@ -29,6 +29,5 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
             Long userId,
             LocalDateTime start,
             LocalDateTime end,
-            List<VerificationStatus> statuses
-    );
+            List<VerificationStatus> statuses);
 }

--- a/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
@@ -14,8 +14,7 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
 
     // 지정된 상태(status)의 인증 요청 목록을 ID 오름차순으로 페이징하여 조회
     Page<Verification> findByStatusOrderByIdAsc(VerificationStatus status, Pageable pageable);
-
-    // 사용자의 인증 요청 목록 조회
+    
     List<Verification> findByUserIdAndCreatedAtBetweenAndStatusIn(
             Long userId,
             LocalDateTime start,

--- a/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
@@ -15,19 +15,19 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
     // 지정된 상태(status)의 인증 요청 목록을 ID 오름차순으로 페이징하여 조회
     Page<Verification> findByStatusOrderByIdAsc(VerificationStatus status, Pageable pageable);
 
-    // 인증 게시글을 기반으로 인증 데이터 삭제
-    void deleteByPost(Post post);
-    
-    // 지정된 상태(status)의 인증 요청 개수 반환
-    long countByStatus(VerificationStatus status);
-
-    // 지정된 상태(status)와 지정된 기간 (start - end)사이 인증 요청 개수 반환
-    long countByStatusInAndUpdatedAtBetween(List<VerificationStatus> statuses, LocalDateTime start, LocalDateTime end);
-
     // 사용자의 인증 요청 목록 조회
     List<Verification> findByUserIdAndCreatedAtBetweenAndStatusIn(
             Long userId,
             LocalDateTime start,
             LocalDateTime end,
             List<VerificationStatus> statuses);
+
+    // 인증 게시글을 기반으로 인증 데이터 삭제
+    void deleteByPost(Post post);
+
+    // 지정된 상태(status)의 인증 요청 개수 반환
+    long countByStatus(VerificationStatus status);
+
+    // 지정된 상태(status)와 지정된 기간 (start - end)사이 인증 요청 개수 반환
+    long countByStatusInAndUpdatedAtBetween(List<VerificationStatus> statuses, LocalDateTime start, LocalDateTime end);
 }

--- a/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
@@ -1,5 +1,6 @@
 package com.dd.blog.domain.post.verification.repository;
 
+import com.dd.blog.domain.post.post.entity.Post;
 import com.dd.blog.domain.post.verification.entity.Verification;
 import com.dd.blog.domain.post.verification.entity.VerificationStatus;
 import org.springframework.data.domain.Page;
@@ -10,4 +11,5 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
 
     // 지정된 상태(status)의 인증 요청 목록을 ID 오름차순으로 페이징하여 조회
     Page<Verification> findByStatusOrderByIdAsc(VerificationStatus status, Pageable pageable);
+    void deleteByPost(Post post);
 }

--- a/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
@@ -7,9 +7,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface VerificationRepository extends JpaRepository<Verification, Long> {
 
     // 지정된 상태(status)의 인증 요청 목록을 ID 오름차순으로 페이징하여 조회
     Page<Verification> findByStatusOrderByIdAsc(VerificationStatus status, Pageable pageable);
+
+    // 인증 게시글을 기반으로 인증 데이터 삭제
     void deleteByPost(Post post);
+    
+    // 지정된 상태(status)의 인증 요청 개수 반환
+    long countByStatus(VerificationStatus status);
+
+    // 지정된 상태(status)와 지정된 기간 (start - end)사이 인증 요청 개수 반환
+    long countByStatusInAndUpdatedAtBetween(List<VerificationStatus> statuses, LocalDateTime start, LocalDateTime end);
 }

--- a/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/verification/repository/VerificationRepository.java
@@ -23,4 +23,12 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
 
     // 지정된 상태(status)와 지정된 기간 (start - end)사이 인증 요청 개수 반환
     long countByStatusInAndUpdatedAtBetween(List<VerificationStatus> statuses, LocalDateTime start, LocalDateTime end);
+
+    // 사용자의 인증 요청 목록 조회
+    List<Verification> findByUserIdAndCreatedAtBetweenAndStatusIn(
+            Long userId,
+            LocalDateTime start,
+            LocalDateTime end,
+            List<VerificationStatus> statuses
+    );
 }

--- a/be/src/main/java/com/dd/blog/domain/user/user/repository/UserRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/user/user/repository/UserRepository.java
@@ -4,10 +4,13 @@ import com.dd.blog.domain.user.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
     Optional<User> findByRefreshToken(String refreshToken);
+
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fe",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@heroicons/react": "~2.2.0",
         "@tanstack/react-query": "^5.74.4",
         "@types/react-datepicker": "^6.2.0",
@@ -282,6 +285,52 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
     },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
@@ -4546,7 +4595,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4942,7 +4990,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5202,7 +5249,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5640,7 +5686,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5757,7 +5802,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@heroicons/react": "~2.2.0",
     "@tanstack/react-query": "^5.74.4",
     "@types/react-datepicker": "^6.2.0",

--- a/fe/src/app/admin/layout.tsx
+++ b/fe/src/app/admin/layout.tsx
@@ -20,7 +20,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const navigation = [
     { name: '대시보드', href: '/admin', icon: 'ri-dashboard-line' },
     { name: '회원 관리', href: '/admin/users', icon: 'ri-user-line' },
-    { name: '인증 관리', href: '/admin/approvals', icon: 'ri-check-double-line' },
+    { name: '인증 관리', href: '/admin/verifications', icon: 'ri-check-double-line' },
     { name: '게시글 관리', href: '/admin/posts', icon: 'ri-file-list-line' },
   ];
 

--- a/fe/src/app/admin/layout.tsx
+++ b/fe/src/app/admin/layout.tsx
@@ -18,10 +18,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const pathname = usePathname();
 
   const navigation = [
-    { name: '대시보드', href: '/admin', icon: 'ri-dashboard-line' },
+    { name: '관리자 대시보드', href: '/admin', icon: 'ri-dashboard-line' },
     { name: '회원 관리', href: '/admin/users', icon: 'ri-user-line' },
     { name: '인증 관리', href: '/admin/verifications', icon: 'ri-check-double-line' },
     { name: '게시글 관리', href: '/admin/posts', icon: 'ri-file-list-line' },
+    { name: '사이트 바로가기', href: '/', icon: 'ri-home-4-line'}
   ];
 
   return (

--- a/fe/src/app/admin/page.tsx
+++ b/fe/src/app/admin/page.tsx
@@ -3,13 +3,47 @@
 
 import React from 'react';
 import Link from 'next/link'; // Next.js 링크 사용
+import {useQuery} from '@tanstack/react-query';
+
+interface AdminDashboardStats {
+    totalUsers: number;
+    pendingVerifications: number;
+    verificationsProcessedToday: number; // '오늘 처리'에 해당
+    usersJoinedToday: number;           // '오늘 가입자'에 해당
+    postsCreatedToday: number;          // '새 게시글(오늘 등록)'에 해당
+    totalPosts: number;                 // '전체 게시글'에 해당
+}
+
 
 export default function AdminDashboardPage() {
 
-  const handleRefresh = () => {
-    // window.location.reload(); // 간단한 페이지 새로고침
-    console.log('페이지 새로고침 (나중에 구현)');
+
+
+   // 백엔드 대시보드 통계 API 호출 함수
+  const fetchDashboardStats = async (): Promise<AdminDashboardStats> => {
+      const response = await fetch('http://localhost:8090/api/admin/dashboard/stats', {
+          credentials: 'include' // 필요시 사용
+          });
+      if (!response.ok) {
+          throw new Error('대시보드 데이터 로딩 실패');
+      }
+      return response.json();
   };
+
+   // useQuery 훅으로 데이터 가져오기
+      const { data: statsData, isLoading, error } = useQuery<AdminDashboardStats>({
+          queryKey: ['adminDashboardStats'], // 이 쿼리의 고유 키
+          queryFn: fetchDashboardStats, // API를 호출할 함수
+   });
+
+   const handleRefresh = () => {
+       queryClient.invalidateQueries({queryKey: ['adminDashboardStats']})
+       console.log('대시보드 데이터 새로고침 요청');
+     };
+
+   if (error) {
+         return <div className="p-6 text-red-500">데이터 로딩 중 에러 발생: {error.message}</div>;
+   }
 
   return (
     // layout.tsx의 {children} 위치에 이 내용이 들어감
@@ -31,19 +65,19 @@ export default function AdminDashboardPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         <div className="bg-white rounded shadow p-6">
           <p className="text-gray-500 mb-2">총 회원 수</p>
-          <p className="text-3xl font-bold text-gray-800">1,234</p> {/* 나중에 데이터 연동 */}
+          <p className="text-3xl font-bold text-gray-800">{isLoading ? '-' : (statsData?.totalUsers ?? 0).toLocaleString()}</p>
         </div>
         <div className="bg-white rounded shadow p-6">
           <p className="text-gray-500 mb-2">승인 대기 인증</p>
-          <p className="text-3xl font-bold text-gray-800">15</p> {/* 나중에 데이터 연동 */}
+          <p className="text-3xl font-bold text-gray-800">{isLoading ? '-' : (statsData?.pendingVerifications ?? 0)}</p>
         </div>
         <div className="bg-white rounded shadow p-6">
           <p className="text-gray-500 mb-2">오늘 가입자</p>
-          <p className="text-3xl font-bold text-gray-800">5</p> {/* 나중에 데이터 연동 */}
+          <p className="text-3xl font-bold text-gray-800">{isLoading ? '-' : (statsData?.usersJoinedToday ?? 0)}</p>
         </div>
         <div className="bg-white rounded shadow p-6">
           <p className="text-gray-500 mb-2">새 게시글</p>
-          <p className="text-3xl font-bold text-gray-800">28</p> {/* 나중에 데이터 연동 */}
+          <p className="text-3xl font-bold text-gray-800">{isLoading ? '-' : (statsData?.postsCreatedToday ?? 0)}</p>
         </div>
       </div>
 
@@ -74,8 +108,8 @@ export default function AdminDashboardPage() {
               <i className="ri-user-line text-2xl" /> {/* 크기 조정 */}
             </div>
           </div>
-          <p className="text-gray-600 mb-4">전체 회원 수: 1,234명</p> {/* 나중에 데이터 연동 */}
-          <p className="text-gray-600 mb-6">오늘 가입: 5명</p> {/* 나중에 데이터 연동 */}
+          <p className="text-gray-600 mb-4">전체 회원 수 : {isLoading ? '-' : (statsData?.totalUsers ?? 0).toLocaleString()} 명</p>
+          <p className="text-gray-600 mb-6">오늘 가입 : {isLoading ? '-' : (statsData?.usersJoinedToday ?? 0)} 명</p>
           <Link href="/admin/users" className="block w-full bg-primary text-white text-center py-3 !rounded-button hover:bg-opacity-90 transition-colors">
             회원 목록 관리
           </Link>
@@ -88,8 +122,8 @@ export default function AdminDashboardPage() {
               <i className="ri-check-double-line text-2xl" /> {/* 크기 조정 */}
             </div>
           </div>
-          <p className="text-gray-600 mb-4">대기 중: 15건</p> {/* 나중에 데이터 연동 */}
-          <p className="text-gray-600 mb-6">오늘 처리: 8건</p> {/* 나중에 데이터 연동 */}
+          <p className="text-gray-600 mb-4">대기 중 : {isLoading ? '-' : (statsData?.pendingVerifications ?? 0)} 건</p>
+          <p className="text-gray-600 mb-6">오늘 처리 : {isLoading ? '-' : (statsData?.verificationsProcessedToday ?? 0)} 건</p>
           <Link href="/admin/verifications" className="block w-full bg-primary text-white text-center py-3 !rounded-button hover:bg-opacity-90 transition-colors">
             인증 승인 관리
           </Link>
@@ -102,8 +136,8 @@ export default function AdminDashboardPage() {
               <i className="ri-file-list-line text-2xl" /> {/* 크기 조정 */}
             </div>
           </div>
-          <p className="text-gray-600 mb-4">전체 게시글: 283개</p> {/* 나중에 데이터 연동 */}
-          <p className="text-gray-600 mb-6">오늘 등록: 28개</p> {/* 나중에 데이터 연동 */}
+          <p className="text-gray-600 mb-4">전체 게시글 : {isLoading ? '-' : (statsData?.totalPosts ?? 0).toLocaleString()} 개</p>
+          <p className="text-gray-600 mb-6">오늘 등록 : {isLoading ? '-' : (statsData?.postsCreatedToday ?? 0)} 개</p>
           <Link href="/admin/posts" className="block w-full bg-primary text-white text-center py-3 !rounded-button hover:bg-opacity-90 transition-colors">
             게시글 관리
           </Link>

--- a/fe/src/app/admin/page.tsx
+++ b/fe/src/app/admin/page.tsx
@@ -55,7 +55,7 @@ export default function AdminDashboardPage() {
           <Link href="/admin/users" className="bg-primary text-white py-3 px-6 !rounded-button whitespace-nowrap">
             회원 목록 관리
           </Link>
-          <Link href="/admin/approvals" className="bg-primary text-white py-3 px-6 !rounded-button whitespace-nowrap">
+          <Link href="/admin/verifications" className="bg-primary text-white py-3 px-6 !rounded-button whitespace-nowrap">
             인증 승인 관리
           </Link>
           <Link href="/admin/posts" className="bg-primary text-white py-3 px-6 !rounded-button whitespace-nowrap">
@@ -90,7 +90,7 @@ export default function AdminDashboardPage() {
           </div>
           <p className="text-gray-600 mb-4">대기 중: 15건</p> {/* 나중에 데이터 연동 */}
           <p className="text-gray-600 mb-6">오늘 처리: 8건</p> {/* 나중에 데이터 연동 */}
-          <Link href="/admin/approvals" className="block w-full bg-primary text-white text-center py-3 !rounded-button hover:bg-opacity-90 transition-colors">
+          <Link href="/admin/verifications" className="block w-full bg-primary text-white text-center py-3 !rounded-button hover:bg-opacity-90 transition-colors">
             인증 승인 관리
           </Link>
         </div>

--- a/fe/src/app/admin/users/[userId]/page.tsx
+++ b/fe/src/app/admin/users/[userId]/page.tsx
@@ -413,15 +413,14 @@ export default function UserDetailPage() {
                         </td>
                       </tr>
                     ) : (
-                      pointHistory.map((history) => ( // ★★★ history 객체 타입 명시 (선택 사항) ★★★
-                        <tr key={history.historyId} className="hover:bg-gray-50"> {/* key는 고유 ID 사용 권장 */}
+                      pointHistory.map((history) => (
+                        <tr key={history.historyId} className="hover:bg-gray-50">
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                             {/* ▼▼▼ history.date -> history.createdAt 으로 수정 + 포맷팅 ▼▼▼ */}
                             {history.createdAt ? new Date(history.createdAt).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '-'}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                            {/* ▼▼▼ history.reason -> history.type 으로 수정 (+ 필요시 변환 함수) ▼▼▼ */}
-                            {history.type} {/* 또는 getPointHistoryReason(history.type) */}
+                            {history.type}
                           </td>
                           <td className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${history.pointChange >= 0 ? 'text-green-600' : 'text-red-600'}`}> {/* ▼▼▼ history.amount -> history.pointChange 로 수정 + 포맷팅 ▼▼▼ */}
                             {history.pointChange >= 0 ? '+' : ''}{history.pointChange.toLocaleString('ko-KR')} P

--- a/fe/src/app/admin/verifications/page.tsx
+++ b/fe/src/app/admin/verifications/page.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useInfiniteQuery, useQueryClient, useMutation } from '@tanstack/react-query';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faTimes, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
+
+// PATCH 요청 본문 타입 정의
+interface VerificationStatusUpdateData {
+  status: 'APPROVED' | 'REJECTED';
+}
+
+
+const AdminVerificationPage: React.FC = () => {
+  // 가상의 인증 요청 데이터
+
+
+  // 인증 요청 처리 함수 (내용은 나중에 채움)
+  const handleApprove = (verificationId: number) => {
+      approveMutation.mutate(verificationId);
+      };
+  const handleReject = (verificationId: number) => {
+      rejectMutation.mutate(verificationId);
+   };
+
+
+  // 시간 포맷팅 함수
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffHours = Math.floor(
+      (now.getTime() - date.getTime()) / (1000 * 60 * 60)
+    );
+    if (diffHours < 24) {
+      return `${diffHours}시간 전`;
+    } else {
+      return date.toLocaleDateString('ko-KR');
+    }
+  };
+
+    const queryClient = useQueryClient(); // QueryClient 인스턴스
+    const observerRef = useRef<IntersectionObserver | null>(null); // IntersectionObserver 참조
+
+    const ADMIN_VERIFICATIONS_API_URL = 'http://localhost:8090/api/admin/verifications';
+
+
+    // 백엔드 API 응답 타입 정의 (Page<Verification> 구조에 맞춰야 함)
+    interface VerificationPage {
+        content: Verification[]; // Verification 타입 배열 (아래 Verification 타입 정의 필요)
+        last: boolean;
+        number: number;
+    }
+
+     interface Verification {
+            verificationId: number; // <-- 'Id' -> 'verificationId' 로 수정!
+            postId: number;         // <-- 'postId?' -> 'postId' 로 수정! (Optional 제거, 타입 number)
+            userId: number;         // <-- DTO에 userId도 있으니 추가 (타입 number)
+            status: string;         // <-- DTO에 status도 있으니 추가 (타입 string - Enum 이름)
+            userNickname: string;
+            verificationImageUrl: string | null; // <-- 이미지 URL은 null일 수도 있으니 | null 추가
+            detoxTime: number;      // <-- DTO 타입이 Integer/int 이므로 number
+            createdAt: string;      // <-- DTO 타입이 LocalDateTime/String이므로 string
+
+
+        }
+
+    // 백엔드 API 호출 함수
+    const fetchPendingVerifications = async ({ pageParam = 0 }): Promise<VerificationPage> => {
+
+      const apiUrl = `${ADMIN_VERIFICATIONS_API_URL}?page=${pageParam}&size=10&sort=createdAt,asc`;
+      console.log("Requesting API:", apiUrl);
+
+      // API URL 수정: '/api/admin/verifications' 사용, PENDING 상태는 기본으로 가져오도록 백엔드에서 처리하거나 파라미터 추가
+      const response = await fetch(apiUrl, {
+          credentials: 'include',
+      });
+
+      if (!response.ok) {
+          throw new Error(`API 호출 실패: ${response.status}`);
+      }
+      const data = await response.json();
+      // 실제 응답 구조 확인 후 data 반환 방식 조정 필요!
+      console.log("Fetched page:", pageParam, data); // 데이터 확인용 로그
+      return data;
+    };
+
+    // useInfiniteQuery 훅 사용
+    const {
+      data,             // 실제 데이터 (pages 배열 형태)
+      fetchNextPage,    // 다음 페이지 로드 함수
+      hasNextPage,      // 다음 페이지 존재 여부
+      isFetchingNextPage, // 다음 페이지 로딩 중 여부
+      isFetching,       // 초기 데이터 로딩 중 여부 (isFetchingNextPage 포함)
+      refetch           // 데이터 새로고침 함수
+    } = useInfiniteQuery({
+      queryKey: ['adminVerifications'], // 쿼리 키
+      queryFn: fetchPendingVerifications, // API 호출 함수
+      initialPageParam: 0, // 초기 페이지 파라미터
+      getNextPageParam: (lastPage) => {
+        // 마지막 페이지면 undefined 반환, 아니면 다음 페이지 번호 반환
+        return lastPage.last ? undefined : lastPage.number + 1;
+      },
+    });
+
+    const approveMutation = useMutation({
+          mutationFn: async (verificationId: number) => {
+            const response = await fetch(`${ADMIN_VERIFICATIONS_API_URL}/${verificationId}`, {
+              method: 'PATCH',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              credentials: 'include', // 필요시 사용
+              body: JSON.stringify({ status: 'APPROVED' } as VerificationStatusUpdateData), // 요청 본문
+            });
+
+            if (!response.ok) {
+              // 에러 처리 강화 (실제 에러 메시지 활용 등)
+              const errorData = await response.text();
+              console.error('승인 실패:', response.status, errorData);
+              throw new Error(`승인 처리 실패: ${response.status}`);
+            }
+            // 성공 시 별도 데이터 반환 안 함 (백엔드 API가 void 반환)
+          },
+          onSuccess: () => {
+            // 성공 시 캐시된 'adminVerifications' 쿼리를 무효화시켜서 목록을 새로고침
+            console.log('승인 성공, 목록 새로고침');
+            queryClient.invalidateQueries({ queryKey: ['adminVerifications'] });
+          },
+          onError: (error) => {
+            // 에러 발생 시 사용자에게 알림 등 추가 처리 가능
+            console.error('승인 처리 중 에러:', error);
+            alert(`승인 처리 중 오류가 발생했습니다: ${error.message}`);
+          }
+        });
+
+
+    const rejectMutation = useMutation({
+          mutationFn: async (verificationId: number) => {
+            const response = await fetch(`${ADMIN_VERIFICATIONS_API_URL}/${verificationId}`, {
+              method: 'PATCH', // 백엔드 AdminVerificationV1Controller의 @PatchMapping 사용
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({ status: 'REJECTED' } as VerificationStatusUpdateData), // 상태를 REJECTED로 보냄
+            });
+            if (!response.ok) {
+              const errorData = await response.text();
+              console.error('거절 실패:', response.status, errorData);
+              throw new Error(`거절 처리 실패: ${response.status}`);
+            }
+          },
+          onSuccess: () => {
+            console.log('거절 성공, 목록 새로고침');
+            // 성공 시 똑같이 목록 새로고침
+            queryClient.invalidateQueries({ queryKey: ['adminVerifications'] });
+          },
+          onError: (error) => {
+            console.error('거절 처리 중 에러:', error);
+            alert(`거절 처리 중 오류가 발생했습니다: ${error.message}`);
+          }
+        });
+
+
+    // 실제 데이터 배열로 변환
+    const requests = data?.pages.flatMap((page) => page.content) || [];
+
+    // 마지막 요소 관찰 콜백 (무한 스크롤 트리거)
+    const lastItemRef = useCallback(
+      (node: HTMLDivElement) => {
+        if (isFetchingNextPage) return; // 로딩 중이면 아무것도 안 함
+
+        if (observerRef.current) {
+          observerRef.current.disconnect(); // 기존 옵저버 연결 해제
+        }
+
+        observerRef.current = new IntersectionObserver((entries) => {
+
+          if (entries[0].isIntersecting && hasNextPage) {
+            console.log('마지막 요소 감지, 다음 페이지 로드');
+            fetchNextPage();
+          }
+        });
+
+        if (node) {
+          observerRef.current.observe(node); // 새 노드에 옵저버 연결
+        }
+      },
+      [fetchNextPage, hasNextPage, isFetchingNextPage]
+    );
+
+    // 컴포넌트 언마운트 시 옵저버 정리
+    useEffect(() => {
+      return () => {
+        if (observerRef.current) {
+          observerRef.current.disconnect();
+        }
+      };
+    }, []);
+
+
+const deleteMutation = useMutation({
+      // mutationFn은 postId를 인자로 받음
+      mutationFn: async (postId: number) => {
+        // 확인된 실제 백엔드 게시글 삭제 API 주소 사용
+        const postDeleteApiUrl = `http://localhost:8090/api/v1/posts/${postId}`;
+
+        console.log("Requesting Post Delete API:", postDeleteApiUrl);
+
+        const response = await fetch(postDeleteApiUrl, {
+          method: 'DELETE', // DELETE 메소드 사용
+          credentials: 'include', // 필요시 사용
+        });
+
+        if (!response.ok) {
+           const errorData = await response.text();
+           console.error('게시글 삭제 실패:', response.status, errorData);
+           // 실제 에러 메시지를 포함하여 throw 하는 것이 더 좋음
+           throw new Error(`게시글 삭제 처리 실패: ${response.status} - ${errorData}`);
+        }
+         // DELETE 성공 시 보통 응답 본문이 없으므로 (204 No Content), 별도 파싱 불필요
+         console.log(`Post (ID: ${postId}) deleted successfully.`);
+      },
+      onSuccess: (data, postId) => { // 성공 시 삭제된 postId도 받을 수 있음
+        console.log(`삭제 성공 (Post ID: ${postId}), 목록 새로고침`);
+        // 삭제 성공 후 관리자 목록 새로고침
+        queryClient.invalidateQueries({ queryKey: ['adminVerifications'] });
+      },
+       onError: (error, postId) => { // 실패 시 postId도 받을 수 있음
+        console.error(`삭제 처리 중 에러 (Post ID: ${postId}):`, error);
+        alert(`삭제 처리 중 오류가 발생했습니다: ${error.message}`);
+      }
+    });
+
+
+
+// 삭제 버튼 클릭 핸들러 - postId를 받도록 수정
+  const handleDelete = (postId: number | undefined | null, verificationId: number) => { // postId가 없을 수도 있으니 타입 가드 추가
+    // postId가 유효한지 먼저 확인
+    if (postId === undefined || postId === null) {
+      console.error("삭제할 게시글 ID를 찾을 수 없습니다.", verificationId);
+      alert("삭제할 게시글 정보를 찾을 수 없습니다.");
+      return;
+    }
+
+    if (window.confirm(`정말로 요청 ID ${verificationId}번 (게시글 ID ${postId}번)을 삭제하시겠습니까? 연결된 게시글이 영구 삭제됩니다.`)) {
+        // 삭제 Mutation 실행 시 postId 전달
+        deleteMutation.mutate(postId);
+    }
+  };
+
+
+  return (
+    <div className="flex h-screen bg-gray-100">
+      {/* 메인 콘텐츠 */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* 상단 헤더 */}
+        <header className="bg-white shadow-sm px-6 py-4">
+          <h2 className="text-2xl font-semibold text-gray-800">
+            도파민 디톡스 인증 관리
+          </h2>
+        </header>
+
+        {/* 메인 콘텐츠 영역 */}
+        {/* 메인 콘텐츠 영역 */}
+        <main className="flex-1 overflow-y-auto p-6 bg-gray-50">
+          <div className="mb-4 flex justify-between items-center">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-800">
+                승인 대기 중인 요청
+              </h2>
+              <p className="text-sm text-gray-500">
+                총 {data?.pages[0]?.totalElements ?? requests.length}개의 요청이 있습니다.</p>
+            </div>
+          </div>
+
+          {/* 인증 요청 목록 */}
+          {/* 초기 로딩 중 표시 */}
+          {isFetching && !isFetchingNextPage && requests.length === 0 && (
+             <div className="flex justify-center items-center py-6">
+               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#F742CD]"></div>
+             </div>
+          )}
+
+          {/* 데이터 없을 때 표시 */}
+          {!isFetching && requests.length === 0 && (
+             <div className="flex flex-col items-center justify-center h-64 bg-white rounded-lg shadow-sm p-6">
+               {/* ... (기존 '요청 없음' UI) ... */}
+                <h3 className="text-lg font-medium text-gray-800">
+                  승인 대기 중인 요청이 없습니다.
+                </h3>
+             </div>
+          )}
+
+          {/* 목록 표시 */}
+          {requests.length > 0 && (
+            <div className="space-y-6">
+              {requests.map((request, index) => {
+                // request 객체 타입 확인 및 안전한 접근 필요
+                if (!request) return null;
+
+                // 마지막 요소에 ref 연결
+                const isLastElement = index === requests.length - 1;
+                return (
+                  <div
+                    key={request.verificationId}
+                    ref={isLastElement ? lastItemRef : null} // <<--- 이 부분 추가!
+                    className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow duration-200"
+                  >
+                    <div className="border-b border-gray-100 px-6 py-4 flex justify-between items-center">
+                      <div className="flex items-center space-x-4">
+                        <span className="text-gray-600">
+                          요청 ID: {request.verificationId}
+                        </span>
+                        <span className="text-gray-600">
+                          {/* user 객체가 중첩되어 있다면 request.user?.nickname */}
+                          닉네임: {request.userNickname}
+                        </span>
+                        <span className="text-gray-600">
+                          디톡스 시간: {request.detoxTime}시간
+                        </span>
+                      </div>
+                      <span className="text-gray-500">
+                        {formatTime(request.createdAt)}
+                      </span>
+                    </div>
+                    <div className="p-6">
+                      <div className="w-full h-[400px] rounded-lg overflow-hidden mb-4">
+                        <img
+                          // post 객체가 중첩되어 있다면 request.post?.verificationImageUrl
+                          src={request.verificationImageUrl || '/placeholder.png'} // 이미지가 없을 경우 대비
+                          alt="인증 이미지"
+                          className="w-full h-full object-cover object-top"
+                        />
+                      </div>
+                      <div className="flex justify-end space-x-3">
+                        <button
+                          onClick={() => handleApprove(request.verificationId)}
+                          className="px-6 py-3 bg-green-500 text-white text-base font-medium rounded hover:bg-green-600 transition-colors cursor-pointer !rounded-button whitespace-nowrap"
+                        >
+                          <FontAwesomeIcon icon={faCheck} className="mr-2" /> 승인
+                        </button>
+                        <button
+                          onClick={() => handleReject(request.verificationId)}
+                          className="px-6 py-3 bg-red-500 text-white text-base font-medium rounded hover:bg-red-600 transition-colors cursor-pointer !rounded-button whitespace-nowrap"
+                        >
+                          <FontAwesomeIcon icon={faTimes} className="mr-2" />거절
+                        </button>
+                        <button
+                          onClick={() => handleDelete(request.postId, request.verificationId)}
+                          className="px-6 py-3 bg-gray-500 text-white text-base font-medium rounded hover:bg-gray-600 transition-colors cursor-pointer !rounded-button whitespace-nowrap"
+                        >
+                          <FontAwesomeIcon icon={faTrashAlt} className="mr-2" /> 삭제
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+             })}
+            </div>
+          )}
+
+          {/* 로딩 상태 및 더 이상 데이터 없음 표시 */}
+          {/* 다음 페이지 로딩 중 */}
+          {isFetchingNextPage && (
+            <div className="flex justify-center items-center py-6">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#F742CD]"></div>
+              <span className="ml-2 text-gray-600">로딩 중...</span>
+            </div>
+          )}
+
+          {/* 더 이상 데이터 없음 */}
+          {!isFetchingNextPage && !hasNextPage && requests.length > 0 && (
+             <div className="text-center py-6 text-gray-500 text-sm">
+               더 이상 요청이 없습니다.
+             </div>
+          )}
+          {/* "더 보기" 버튼은 IntersectionObserver 사용 시 필요 없음 (삭제) */}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminVerificationPage;

--- a/fe/src/app/layout.tsx
+++ b/fe/src/app/layout.tsx
@@ -1,3 +1,7 @@
+import { config } from '@fortawesome/fontawesome-svg-core'
+import '@fortawesome/fontawesome-svg-core/styles.css'
+config.autoAddCss = false
+
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";

--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -621,7 +621,6 @@ export default function Home() {
     }
   };
 
-<<<<<<< HEAD
   const renderAdminButton = () => (
         <Link href="/admin" className="mt-3 block w-full bg-pink-500 text-white py-3 px-4 rounded-full hover:bg-pink-600 transition font-medium text-center">
           관리자 대시보드
@@ -629,7 +628,6 @@ export default function Home() {
       );
 
 
-=======
   // 댓글 수 업데이트 핸들러
   const handleCommentUpdate = async (postId: number, count: number) => {
     // React Query 캐시 업데이트
@@ -665,7 +663,6 @@ export default function Home() {
   const memoizedHandleUnlike = useCallback((postId: number) => {
     handleUnlike(postId);
   }, []);
->>>>>>> 4e565b2a3821ce88ada9246c9aff6b2db7db3981
 
   const posts = data?.pages.flatMap((page) => page.content) || [];
 

--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -338,6 +338,14 @@ export default function Home() {
     }
   };
 
+  const renderAdminButton = () => (
+        <Link href="/admin" className="mt-3 block w-full bg-pink-500 text-white py-3 px-4 rounded-full hover:bg-pink-600 transition font-medium text-center">
+          관리자 대시보드
+        </Link>
+      );
+
+
+
   const posts = data?.pages.flatMap((page) => page.content) || [];
 
   return (
@@ -421,12 +429,18 @@ export default function Home() {
                     </div>
                   </div>
 
-                  <button
-                    onClick={openWriteModal}
-                    className="mt-3 w-full bg-pink-500 text-white py-3 px-4 rounded-full hover:bg-pink-600 transition font-medium"
-                  >
-                    오늘 인증하기
-                  </button>
+                  {user && ( // 로그인된 상태인지 먼저 확인
+                      user.role === 'ROLE_ADMIN'
+                        ? renderAdminButton()
+                        : (
+                            <button
+                              onClick={openWriteModal}
+                              className="mt-3 w-full bg-pink-500 text-white py-3 px-4 rounded-full hover:bg-pink-600 transition font-medium"
+                            >
+                              오늘 인증하기
+                             </button>
+                           )
+                   )}
 
                   <div className="mt-4 w-full">
                     <p className="text-sm font-medium text-gray-800 mb-3">

--- a/fe/src/components/Post.tsx
+++ b/fe/src/components/Post.tsx
@@ -222,7 +222,7 @@ export default function Post({
               </span>
             </div>
             <div className="group">
-              {user?.id === userId && (
+              {(user?.id === userId || user?.role === 'ROLE_ADMIN') &&  (
                 <button
                   onClick={() => setShowDeleteConfirm(true)}
                   className="text-gray-400 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"


### PR DESCRIPTION
### 1️⃣관련 이슈
이슈 링크 달아주세요. 

🔗
</br>
#90
</br>
.
### 2️⃣작업 내용
어떤 기능을 구현했는지 간단히 설명

✒️
</br>

관리자 승인 페이지 및 백엔드 연동 완료 (이미지 엑박부분 수정 필요)
관리자 메인 대시보드 페이지 백엔드 연동 완료
관리자는 모든 유저의 게시글 삭제 가능
관리자 사이드바에 메인 홈페이지 이동버튼 추가
로그인 후 메인 페이지에서 관리자 프로필 하단 버튼 변경 

</br>

.
### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [X] 로컬에서 테스트 완료 🧪🫧
✒️
</br>
직접 프론트 화면에서 테스트
</br>



