### PR TITLE
[FEAT] 프로필페이지 - 팔로우/언팔로우, 팔로우목록조회 

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/user/follow/controller/ApiV1FollowerController.java
+++ b/be/src/main/java/com/dd/blog/domain/user/follow/controller/ApiV1FollowerController.java
@@ -2,6 +2,7 @@ package com.dd.blog.domain.user.follow.controller;
 
 import com.dd.blog.domain.user.follow.dto.FollowRequestDto;
 import com.dd.blog.domain.user.follow.dto.FollowResponseDto;
+import com.dd.blog.domain.user.follow.dto.FollowUserDto;
 import com.dd.blog.domain.user.follow.entity.Follow;
 import com.dd.blog.domain.user.follow.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,12 +31,12 @@ public class ApiV1FollowerController {
         return ResponseEntity.status(HttpStatus.CREATED).body(follow);
     }
 
-    @DeleteMapping("/{followId}")
+    @DeleteMapping("/{followerId}/{followingId}")
     @Operation(summary = "팔로우 취소", description = "팔로우를 취소합니다.")
     public ResponseEntity<Void> unfollow(
-            @RequestParam Long userId,
-            @PathVariable Long followId) {
-        followService.unfollow(userId, followId);
+            @PathVariable Long followerId,
+            @PathVariable Long followingId) {
+        followService.unfollow(followerId, followingId);
         return ResponseEntity.ok().build();
     }
 
@@ -48,20 +49,20 @@ public class ApiV1FollowerController {
         return ResponseEntity.ok(isFollowing);
     }
 
-    @GetMapping("/{userId}/followers/nicknames")
+    @GetMapping("/{userId}/followers")
     @Operation(summary = "팔로워 조회", description = "나를 팔로우 하는 사람들을 조회합니다.")
-    public ResponseEntity<List<String>> getFollowers(@PathVariable Long userId){
-        List<String> followers = followService.getFollowers(userId).stream()
-                .map(FollowResponseDto::getFollowerNickname)
+    public ResponseEntity<List<FollowUserDto>> getFollowers(@PathVariable Long userId){
+        List<FollowUserDto> followers = followService.getFollowers(userId).stream()
+                .map(dto -> new FollowUserDto(dto.getFollowerId(), dto.getFollowerNickname()))
                 .collect(Collectors.toList());
         return ResponseEntity.ok(followers);
     }
 
-    @GetMapping("/{userId}/followings/nicknames")
+    @GetMapping("/{userId}/followings")
     @Operation(summary = "팔로잉 조회", description = "내가 팔로우 하는 사람들을 조회합니다.")
-    public ResponseEntity<List<String>> getFollowings(@PathVariable Long userId){
-        List<String> followings = followService.getFollowings(userId).stream()
-                .map(FollowResponseDto::getFollowingNickname)
+    public ResponseEntity<List<FollowUserDto>> getFollowings(@PathVariable Long userId){
+        List<FollowUserDto> followings = followService.getFollowings(userId).stream()
+                .map(dto -> new FollowUserDto(dto.getFollowingId(), dto.getFollowingNickname()))
                 .collect(Collectors.toList());
         return ResponseEntity.ok(followings);
     }

--- a/be/src/main/java/com/dd/blog/domain/user/follow/controller/ApiV1FollowerController.java
+++ b/be/src/main/java/com/dd/blog/domain/user/follow/controller/ApiV1FollowerController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@RestController
 @RequestMapping("/api/v1/follows")
 @RequiredArgsConstructor
 @Tag(name = "Follow", description = "팔로우 관련 API")
@@ -80,7 +81,4 @@ public class ApiV1FollowerController {
         int followingNum = followService.getFollowings(userId).size();
         return ResponseEntity.ok(followingNum);
     }
-
-    // TODO: 팔로워/팔로잉 목록 조회
-
 }

--- a/be/src/main/java/com/dd/blog/domain/user/follow/dto/FollowUserDto.java
+++ b/be/src/main/java/com/dd/blog/domain/user/follow/dto/FollowUserDto.java
@@ -1,0 +1,15 @@
+package com.dd.blog.domain.user.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FollowUserDto {
+    private Long id;
+    private String nickname;
+}

--- a/be/src/main/java/com/dd/blog/domain/user/follow/service/FollowService.java
+++ b/be/src/main/java/com/dd/blog/domain/user/follow/service/FollowService.java
@@ -89,7 +89,7 @@ public class FollowService {
         User follower = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
-        List<Follow> followerList = followRepository.findByFollower(follower);
+        List<Follow> followerList = followRepository.findByFollowing(follower);
 
         return followerList.stream()
                 .map(FollowResponseDto::fromEntity)
@@ -103,7 +103,7 @@ public class FollowService {
         User following = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
-        List<Follow> followingList = followRepository.findByFollowing(following);
+        List<Follow> followingList = followRepository.findByFollower(following);
 
         return followingList.stream()
                 .map(FollowResponseDto::fromEntity)

--- a/be/src/main/java/com/dd/blog/domain/user/follow/service/FollowService.java
+++ b/be/src/main/java/com/dd/blog/domain/user/follow/service/FollowService.java
@@ -48,13 +48,13 @@ public class FollowService {
 
 
     @Transactional
-    public void unfollow(Long followerId, Long followingId){
-        User follower = userRepository.findById(followerId)
+    public void unfollow(Long userId, Long followingId){
+        User follower = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
         User following = userRepository.findById(followingId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
-        // follower가 팔로우한 사람들 리스트 가져오기
+        // 내가 팔로우한 사람들 리스트 가져오기
         List<Follow> followList = followRepository.findByFollower(follower);
 
         // 이미 팔로우 중인지 확인

--- a/fe/src/app/profile/[id]/page.tsx
+++ b/fe/src/app/profile/[id]/page.tsx
@@ -54,10 +54,10 @@ export default function OtherUserProfile() {
   const [showFollowersModal, setShowFollowersModal] = useState(false);
   const [showFollowingModal, setShowFollowingModal] = useState(false);
   const [followers, setFollowers] = useState<
-    { nickname: string; id: number }[]
+    { id: number; nickname: string }[]
   >([]);
   const [followings, setFollowings] = useState<
-    { nickname: string; id: number }[]
+    { id: number; nickname: string }[]
   >([]);
   const [isLoadingFollows, setIsLoadingFollows] = useState(false);
 
@@ -276,24 +276,17 @@ export default function OtherUserProfile() {
   const fetchFollowers = async (userId: number) => {
     try {
       setIsLoadingFollows(true);
-      // 실제로는 API가 닉네임만 반환하지만, 프론트에서 테스트용으로 ID를 임시 부여
+      // 새로운 API 엔드포인트로 수정 - 닉네임과 ID를 모두 반환하는 새 엔드포인트
       const response = await fetch(
-        `http://localhost:8090/api/v1/follows/${userId}/followers/nicknames`,
+        `http://localhost:8090/api/v1/follows/${userId}/followers`,
         {
           credentials: "include",
         }
       );
 
       if (response.ok) {
-        const nicknames = await response.json();
-        // 닉네임 목록에 임시 ID 할당 (실제 환경에서는 백엔드에서 ID도 함께 반환하도록 수정 필요)
-        const followersWithIds = nicknames.map(
-          (nickname: string, index: number) => ({
-            nickname,
-            id: parseInt(userId) + index + 100, // 임시 ID 생성 (실제 환경에서는 사용하지 않음)
-          })
-        );
-        setFollowers(followersWithIds);
+        const data = await response.json();
+        setFollowers(data); // 응답이 이미 {id, nickname} 형태이므로 그대로 사용
       }
     } catch (error) {
       console.error("Error fetching followers:", error);
@@ -306,23 +299,17 @@ export default function OtherUserProfile() {
   const fetchFollowings = async (userId: number) => {
     try {
       setIsLoadingFollows(true);
+      // 새로운 API 엔드포인트로 수정 - 닉네임과 ID를 모두 반환하는 새 엔드포인트
       const response = await fetch(
-        `http://localhost:8090/api/v1/follows/${userId}/followings/nicknames`,
+        `http://localhost:8090/api/v1/follows/${userId}/followings`,
         {
           credentials: "include",
         }
       );
 
       if (response.ok) {
-        const nicknames = await response.json();
-        // 닉네임 목록에 임시 ID 할당 (실제 환경에서는 백엔드에서 ID도 함께 반환하도록 수정 필요)
-        const followingsWithIds = nicknames.map(
-          (nickname: string, index: number) => ({
-            nickname,
-            id: parseInt(userId) + index + 200, // 임시 ID 생성 (실제 환경에서는 사용하지 않음)
-          })
-        );
-        setFollowings(followingsWithIds);
+        const data = await response.json();
+        setFollowings(data); // 응답이 이미 {id, nickname} 형태이므로 그대로 사용
       }
     } catch (error) {
       console.error("Error fetching followings:", error);

--- a/fe/src/app/profile/[id]/page.tsx
+++ b/fe/src/app/profile/[id]/page.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import { useState, useEffect } from 'react';
-import { useRouter, useParams } from 'next/navigation';
-import { UserInfo } from '@/types/user';
+import Image from "next/image";
+import { useState, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { UserInfo } from "@/types/user";
 
 interface Post {
   postId: number;
@@ -28,66 +28,86 @@ export default function OtherUserProfile() {
   const [isFollowing, setIsFollowing] = useState(false);
   const [userInfo, setUserInfo] = useState<UserInfo>({
     id: null,
-    nickname: '',
-    email: '',
+    nickname: "",
+    email: "",
     remainingPoint: 0,
     totalPoint: 0,
     createdAt: null,
-    statusMessage: ''
+    statusMessage: "",
   });
   const [followStats, setFollowStats] = useState({
     followers: 0,
-    following: 0
+    following: 0,
   });
   const [stats] = useState({
     detoxDays: 45,
     streakDays: 12,
     detoxTime: 32,
-    badges: 8
+    badges: 8,
   });
 
-  const [selectedTab, setSelectedTab] = useState('feed');
+  const [selectedTab, setSelectedTab] = useState("feed");
   const [posts, setPosts] = useState<Post[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // 팔로워/팔로잉 모달 상태
+  const [showFollowersModal, setShowFollowersModal] = useState(false);
+  const [showFollowingModal, setShowFollowingModal] = useState(false);
+  const [followers, setFollowers] = useState<
+    { nickname: string; id: number }[]
+  >([]);
+  const [followings, setFollowings] = useState<
+    { nickname: string; id: number }[]
+  >([]);
+  const [isLoadingFollows, setIsLoadingFollows] = useState(false);
 
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
         setIsLoading(true);
         // 먼저 현재 로그인한 사용자 정보를 가져와서 본인 프로필인지 확인
-        const meResponse = await fetch('http://localhost:8090/api/v1/users/me', {
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-        
+        const meResponse = await fetch(
+          "http://localhost:8090/api/v1/users/me",
+          {
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+
         if (meResponse.ok) {
           const meData = await meResponse.json();
           // 본인 프로필이면 /profile/me로 리다이렉트
           if (meData.id.toString() === userId) {
-            router.push('/profile/me');
+            router.push("/profile/me");
             return;
           }
-          
-          // 팔로우 상태 확인 (실제 API 연동 시 구현)
-          // const followStatusResponse = await fetch(`http://localhost:8090/api/v1/follows/check/${userId}`, {
-          //   credentials: 'include'
-          // });
-          // if (followStatusResponse.ok) {
-          //   const followStatus = await followStatusResponse.json();
-          //   setIsFollowing(followStatus);
-          // }
+
+          // 팔로우 상태 확인 - 주석 해제하고 구현
+          const followStatusResponse = await fetch(
+            `http://localhost:8090/api/v1/follows/check?followerId=${meData.id}&followingId=${userId}`,
+            {
+              credentials: "include",
+            }
+          );
+          if (followStatusResponse.ok) {
+            const followStatus = await followStatusResponse.json();
+            setIsFollowing(followStatus);
+          }
         }
 
         // 요청된 사용자의 프로필 정보 가져오기
-        const response = await fetch(`http://localhost:8090/api/v1/users/${userId}`, {
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-        
+        const response = await fetch(
+          `http://localhost:8090/api/v1/users/${userId}`,
+          {
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+
         if (response.ok) {
           const data = await response.json();
           setUserInfo(data);
@@ -95,11 +115,11 @@ export default function OtherUserProfile() {
           fetchFollowStats(data.id);
           fetchUserPosts(data.id);
         } else {
-          console.error('Failed to fetch user info');
-          router.push('/404'); // 사용자를 찾을 수 없는 경우 404 페이지로 이동
+          console.error("Failed to fetch user info");
+          router.push("/404"); // 사용자를 찾을 수 없는 경우 404 페이지로 이동
         }
       } catch (error) {
-        console.error('Error fetching user info:', error);
+        console.error("Error fetching user info:", error);
       } finally {
         setIsLoading(false);
       }
@@ -113,12 +133,18 @@ export default function OtherUserProfile() {
   const fetchFollowStats = async (userId: number) => {
     try {
       const [followersRes, followingRes] = await Promise.all([
-        fetch(`http://localhost:8090/api/v1/follows/${userId}/followers/number`, {
-          credentials: 'include'
-        }),
-        fetch(`http://localhost:8090/api/v1/follows/${userId}/followings/number`, {
-          credentials: 'include'
-        })
+        fetch(
+          `http://localhost:8090/api/v1/follows/${userId}/followers/number`,
+          {
+            credentials: "include",
+          }
+        ),
+        fetch(
+          `http://localhost:8090/api/v1/follows/${userId}/followings/number`,
+          {
+            credentials: "include",
+          }
+        ),
       ]);
 
       if (followersRes.ok && followingRes.ok) {
@@ -127,36 +153,107 @@ export default function OtherUserProfile() {
         setFollowStats({ followers, following });
       }
     } catch (error) {
-      console.error('Error fetching follow stats:', error);
+      console.error("Error fetching follow stats:", error);
     }
   };
 
   const fetchUserPosts = async (userId: number) => {
     try {
-      const response = await fetch(`http://localhost:8090/api/v1/posts/user/${userId}`, {
-        credentials: 'include'
-      });
+      const response = await fetch(
+        `http://localhost:8090/api/v1/posts/user/${userId}`,
+        {
+          credentials: "include",
+        }
+      );
 
       if (response.ok) {
         const data = await response.json();
         setPosts(data);
       }
     } catch (error) {
-      console.error('Error fetching user posts:', error);
+      console.error("Error fetching user posts:", error);
     }
   };
 
-  const handleFollowToggle = () => {
-    // 팔로우 기능 구현 (추후 API 연동)
-    setIsFollowing(!isFollowing);
-    // TODO: API 호출로 팔로우/언팔로우 처리
+  const handleFollowToggle = async () => {
+    try {
+      // 현재 로그인한 사용자 정보 가져오기
+      const meResponse = await fetch("http://localhost:8090/api/v1/users/me", {
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!meResponse.ok) {
+        console.error("Failed to fetch current user info");
+        return;
+      }
+
+      const meData = await meResponse.json();
+
+      if (isFollowing) {
+        // 언팔로우 로직 - 백엔드 API 수정사항 반영
+        // 이제 followerId와 followingId 모두 @PathVariable로 경로에 포함
+        const unfollowResponse = await fetch(
+          `http://localhost:8090/api/v1/follows/${meData.id}/${userInfo.id}`,
+          {
+            method: "DELETE",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+
+        if (unfollowResponse.ok) {
+          setIsFollowing(false);
+          // 팔로워 수 업데이트
+          if (userInfo.id !== null) {
+            fetchFollowStats(userInfo.id);
+          }
+        } else {
+          console.error("Failed to unfollow");
+        }
+      } else {
+        // 팔로우 로직 - 이 부분은 백엔드 API와 일치함
+        const followResponse = await fetch(
+          "http://localhost:8090/api/v1/follows",
+          {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              followerId: meData.id,
+              followingId: userInfo.id,
+            }),
+          }
+        );
+
+        if (followResponse.ok) {
+          setIsFollowing(true);
+          // 팔로워 수 업데이트
+          if (userInfo.id !== null) {
+            fetchFollowStats(userInfo.id);
+          }
+        } else {
+          console.error("Failed to follow");
+        }
+      }
+    } catch (error) {
+      console.error("Error toggling follow status:", error);
+    }
   };
 
   // 날짜 포맷 함수
   const formatDate = (dateString: string) => {
-    if (!dateString) return '';
+    if (!dateString) return "";
     const date = new Date(dateString);
-    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+    return `${date.getFullYear()}년 ${
+      date.getMonth() + 1
+    }월 ${date.getDate()}일`;
   };
 
   // 시간 경과 표시 함수
@@ -164,7 +261,7 @@ export default function OtherUserProfile() {
     const date = new Date(dateString);
     const now = new Date();
     const diff = now.getTime() - date.getTime();
-    
+
     const minutes = Math.floor(diff / 60000);
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
@@ -172,7 +269,91 @@ export default function OtherUserProfile() {
     if (days > 0) return `${days}일 전`;
     if (hours > 0) return `${hours}시간 전`;
     if (minutes > 0) return `${minutes}분 전`;
-    return '방금 전';
+    return "방금 전";
+  };
+
+  // 팔로워 목록 가져오기
+  const fetchFollowers = async (userId: number) => {
+    try {
+      setIsLoadingFollows(true);
+      // 실제로는 API가 닉네임만 반환하지만, 프론트에서 테스트용으로 ID를 임시 부여
+      const response = await fetch(
+        `http://localhost:8090/api/v1/follows/${userId}/followers/nicknames`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        const nicknames = await response.json();
+        // 닉네임 목록에 임시 ID 할당 (실제 환경에서는 백엔드에서 ID도 함께 반환하도록 수정 필요)
+        const followersWithIds = nicknames.map(
+          (nickname: string, index: number) => ({
+            nickname,
+            id: parseInt(userId) + index + 100, // 임시 ID 생성 (실제 환경에서는 사용하지 않음)
+          })
+        );
+        setFollowers(followersWithIds);
+      }
+    } catch (error) {
+      console.error("Error fetching followers:", error);
+    } finally {
+      setIsLoadingFollows(false);
+    }
+  };
+
+  // 팔로잉 목록 가져오기
+  const fetchFollowings = async (userId: number) => {
+    try {
+      setIsLoadingFollows(true);
+      const response = await fetch(
+        `http://localhost:8090/api/v1/follows/${userId}/followings/nicknames`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        const nicknames = await response.json();
+        // 닉네임 목록에 임시 ID 할당 (실제 환경에서는 백엔드에서 ID도 함께 반환하도록 수정 필요)
+        const followingsWithIds = nicknames.map(
+          (nickname: string, index: number) => ({
+            nickname,
+            id: parseInt(userId) + index + 200, // 임시 ID 생성 (실제 환경에서는 사용하지 않음)
+          })
+        );
+        setFollowings(followingsWithIds);
+      }
+    } catch (error) {
+      console.error("Error fetching followings:", error);
+    } finally {
+      setIsLoadingFollows(false);
+    }
+  };
+
+  // 팔로워 모달 열기
+  const handleShowFollowers = () => {
+    if (userInfo.id !== null) {
+      fetchFollowers(userInfo.id);
+      setShowFollowersModal(true);
+      setShowFollowingModal(false);
+    }
+  };
+
+  // 팔로잉 모달 열기
+  const handleShowFollowing = () => {
+    if (userInfo.id !== null) {
+      fetchFollowings(userInfo.id);
+      setShowFollowingModal(true);
+      setShowFollowersModal(false);
+    }
+  };
+
+  // 유저 프로필로 이동
+  const navigateToUserProfile = (userId: number) => {
+    setShowFollowersModal(false);
+    setShowFollowingModal(false);
+    router.push(`/profile/${userId.toString()}`);
   };
 
   if (isLoading) {
@@ -184,7 +365,7 @@ export default function OtherUserProfile() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-4">
+    <div className="max-w-2xl mx-auto p-4 bg-white min-h-screen">
       {/* Profile Header */}
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-4">
@@ -199,46 +380,154 @@ export default function OtherUserProfile() {
             <div className="absolute bottom-0 right-0 w-4 h-4 bg-gray-500 rounded-full border-2 border-white"></div>
           </div>
           <div>
-            <h1 className="text-xl font-semibold">@{userInfo.nickname || 'loading...'}</h1>
+            <h1 className="text-xl font-semibold">
+              @{userInfo.nickname || "loading..."}
+            </h1>
             <div className="flex gap-4 my-2 text-sm">
-              <div className="flex items-center gap-1">
+              <div
+                className="flex items-center gap-1 cursor-pointer hover:text-pink-500"
+                onClick={handleShowFollowers}
+              >
                 <span className="font-semibold">{followStats.followers}</span>
-                <span className="text-gray-600">팔로워</span>
+                <span className="text-gray-600 hover:text-pink-500">
+                  팔로워
+                </span>
               </div>
-              <div className="flex items-center gap-1">
+              <div
+                className="flex items-center gap-1 cursor-pointer hover:text-pink-500"
+                onClick={handleShowFollowing}
+              >
                 <span className="font-semibold">{followStats.following}</span>
-                <span className="text-gray-600">팔로잉</span>
+                <span className="text-gray-600 hover:text-pink-500">
+                  팔로잉
+                </span>
               </div>
             </div>
-            <p className="text-gray-600 text-sm">{userInfo.statusMessage || '상태 메시지가 없습니다.'}</p>
-            <p className="text-gray-400 text-xs mt-1">가입일: {formatDate(userInfo.createdAt || '')}</p>
+            <p className="text-gray-600 text-sm">
+              {userInfo.statusMessage || "상태 메시지가 없습니다."}
+            </p>
+            <p className="text-gray-400 text-xs mt-1">
+              가입일: {formatDate(userInfo.createdAt || "")}
+            </p>
           </div>
         </div>
-        <button 
+        <button
           onClick={handleFollowToggle}
           className={`px-4 py-2 rounded-full text-sm transition-colors ${
-            isFollowing 
-              ? 'bg-gray-200 text-gray-800 hover:bg-gray-300' 
-              : 'bg-pink-500 text-white hover:bg-pink-600'
+            isFollowing
+              ? "bg-white text-black border border-gray-300 hover:bg-gray-100"
+              : "bg-pink-500 text-white hover:bg-pink-600"
           }`}
         >
-          {isFollowing ? '팔로잉' : '팔로우'}
+          {isFollowing ? "언팔로우" : "팔로우"}
         </button>
       </div>
+
+      {/* 팔로워 모달 */}
+      {showFollowersModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-4 w-72 max-w-sm">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold">팔로워</h3>
+              <button
+                onClick={() => setShowFollowersModal(false)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                &times;
+              </button>
+            </div>
+            <div className="overflow-y-auto max-h-60">
+              {isLoadingFollows ? (
+                <div className="flex justify-center py-4">
+                  <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-pink-500"></div>
+                </div>
+              ) : followers.length > 0 ? (
+                <ul className="space-y-2">
+                  {followers.map((follower, index) => (
+                    <li
+                      key={index}
+                      className="py-2 px-3 hover:bg-gray-100 rounded cursor-pointer"
+                      onClick={() => navigateToUserProfile(follower.id)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
+                        <span>@{follower.nickname}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-center text-gray-500 py-4">
+                  팔로워가 없습니다.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 팔로잉 모달 */}
+      {showFollowingModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-4 w-72 max-w-sm">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold">팔로잉</h3>
+              <button
+                onClick={() => setShowFollowingModal(false)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                &times;
+              </button>
+            </div>
+            <div className="overflow-y-auto max-h-60">
+              {isLoadingFollows ? (
+                <div className="flex justify-center py-4">
+                  <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-pink-500"></div>
+                </div>
+              ) : followings.length > 0 ? (
+                <ul className="space-y-2">
+                  {followings.map((following, index) => (
+                    <li
+                      key={index}
+                      className="py-2 px-3 hover:bg-gray-100 rounded cursor-pointer"
+                      onClick={() => navigateToUserProfile(following.id)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
+                        <span>@{following.nickname}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-center text-gray-500 py-4">
+                  팔로잉하는 사용자가 없습니다.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Stats Grid */}
       <div className="grid grid-cols-3 gap-4 mb-8">
         <div className="text-center">
           <p className="text-gray-600">총 인증일수</p>
-          <p className="text-2xl font-bold text-pink-500">{stats.detoxDays}일</p>
+          <p className="text-2xl font-bold text-pink-500">
+            {stats.detoxDays}일
+          </p>
         </div>
         <div className="text-center">
-          <p className="text-gray-600">현재 스트릭</p>
-          <p className="text-2xl font-bold text-pink-500">{stats.streakDays}일</p>
+          <p className="text-gray-600">연속인증일수</p>
+          <p className="text-2xl font-bold text-pink-500">
+            {stats.streakDays}일
+          </p>
         </div>
         <div className="text-center">
           <p className="text-gray-600">현재 포인트</p>
-          <p className="text-2xl font-bold text-pink-500">{userInfo.remainingPoint} P</p>
+          <p className="text-2xl font-bold text-pink-500">
+            {userInfo.remainingPoint} P
+          </p>
         </div>
       </div>
 
@@ -250,9 +539,9 @@ export default function OtherUserProfile() {
             <span className="text-sm text-pink-500">{stats.detoxTime}시간</span>
           </div>
           <div className="h-2 bg-gray-200 rounded-full">
-            <div 
+            <div
               className="h-full bg-pink-500 rounded-full"
-              style={{ width: `${(stats.detoxTime/48)*100}%` }}
+              style={{ width: `${(stats.detoxTime / 48) * 100}%` }}
             ></div>
           </div>
         </div>
@@ -262,11 +551,16 @@ export default function OtherUserProfile() {
       <div className="mb-8">
         <h2 className="text-lg font-semibold mb-4">획득한 뱃지</h2>
         <div className="grid grid-cols-4 gap-4">
-          {Array(stats.badges).fill(0).map((_, i) => (
-            <div key={i} className="aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
-              <span className="text-3xl">🏆</span>
-            </div>
-          ))}
+          {Array(stats.badges)
+            .fill(0)
+            .map((_, i) => (
+              <div
+                key={i}
+                className="aspect-square bg-gray-100 rounded-lg flex items-center justify-center"
+              >
+                <span className="text-3xl">🏆</span>
+              </div>
+            ))}
         </div>
       </div>
 
@@ -276,21 +570,21 @@ export default function OtherUserProfile() {
         <div className="border-b border-gray-200 mb-4">
           <nav className="flex gap-4">
             <button
-              onClick={() => setSelectedTab('feed')}
+              onClick={() => setSelectedTab("feed")}
               className={`pb-4 px-2 ${
-                selectedTab === 'feed'
-                  ? 'border-b-2 border-pink-500 text-pink-500'
-                  : 'text-gray-500'
+                selectedTab === "feed"
+                  ? "border-b-2 border-pink-500 text-pink-500"
+                  : "text-gray-500"
               }`}
             >
               피드
             </button>
             <button
-              onClick={() => setSelectedTab('comments')}
+              onClick={() => setSelectedTab("comments")}
               className={`pb-4 px-2 ${
-                selectedTab === 'comments'
-                  ? 'border-b-2 border-pink-500 text-pink-500'
-                  : 'text-gray-500'
+                selectedTab === "comments"
+                  ? "border-b-2 border-pink-500 text-pink-500"
+                  : "text-gray-500"
               }`}
             >
               댓글
@@ -298,25 +592,32 @@ export default function OtherUserProfile() {
           </nav>
         </div>
 
-        {selectedTab === 'feed' && (
+        {selectedTab === "feed" && (
           <div className="grid grid-cols-2 gap-4">
             {posts.length > 0 ? (
               posts.map((post) => (
-                <div key={post.postId} className="bg-white rounded-lg shadow p-4">
+                <div
+                  key={post.postId}
+                  className="bg-white rounded-lg shadow p-4"
+                >
                   <div className="flex items-center gap-2 mb-3">
                     <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
                     <div>
-                      <p className="text-sm font-medium">@{post.userNickname}</p>
-                      <p className="text-xs text-gray-500">{getTimeAgo(post.createdAt)}</p>
+                      <p className="text-sm font-medium">
+                        @{post.userNickname}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {getTimeAgo(post.createdAt)}
+                      </p>
                     </div>
                   </div>
                   {post.imageUrl && (
                     <div className="aspect-video bg-gray-100 rounded-lg mb-3 overflow-hidden">
-                      <Image 
-                        src={post.imageUrl} 
-                        alt="Post image" 
-                        width={300} 
-                        height={200} 
+                      <Image
+                        src={post.imageUrl}
+                        alt="Post image"
+                        width={300}
+                        height={200}
                         className="w-full h-full object-cover"
                       />
                     </div>
@@ -326,14 +627,18 @@ export default function OtherUserProfile() {
                 </div>
               ))
             ) : (
-              <p className="text-gray-500 col-span-2 text-center py-8">아직 작성한 글이 없습니다.</p>
+              <p className="text-gray-500 col-span-2 text-center py-8">
+                아직 작성한 글이 없습니다.
+              </p>
             )}
           </div>
         )}
 
-        {selectedTab === 'comments' && (
+        {selectedTab === "comments" && (
           <div className="space-y-4">
-            <p className="text-gray-500 text-center py-8">아직 작성한 댓글이 없습니다.</p>
+            <p className="text-gray-500 text-center py-8">
+              아직 작성한 댓글이 없습니다.
+            </p>
           </div>
         )}
       </div>

--- a/fe/src/app/profile/[id]/page.tsx
+++ b/fe/src/app/profile/[id]/page.tsx
@@ -194,7 +194,6 @@ export default function OtherUserProfile() {
 
       if (isFollowing) {
         // 언팔로우 로직 - 백엔드 API 수정사항 반영
-        // 이제 followerId와 followingId 모두 @PathVariable로 경로에 포함
         const unfollowResponse = await fetch(
           `http://localhost:8090/api/v1/follows/${meData.id}/${userInfo.id}`,
           {
@@ -213,10 +212,19 @@ export default function OtherUserProfile() {
             fetchFollowStats(userInfo.id);
           }
         } else {
-          console.error("Failed to unfollow");
+          console.error(
+            `Failed to unfollow. Status: ${unfollowResponse.status}`,
+            await unfollowResponse.text()
+          );
         }
       } else {
-        // 팔로우 로직 - 이 부분은 백엔드 API와 일치함
+        // 팔로우 로직
+        // API 엔드포인트 확인 - "/api/v1/follows"로 POST 요청
+        console.log("Sending follow request:", {
+          followerId: meData.id,
+          followingId: userInfo.id,
+        });
+
         const followResponse = await fetch(
           "http://localhost:8090/api/v1/follows",
           {
@@ -239,7 +247,10 @@ export default function OtherUserProfile() {
             fetchFollowStats(userInfo.id);
           }
         } else {
-          console.error("Failed to follow");
+          console.error(
+            `Failed to follow. Status: ${followResponse.status}`,
+            await followResponse.text()
+          );
         }
       }
     } catch (error) {
@@ -272,11 +283,10 @@ export default function OtherUserProfile() {
     return "방금 전";
   };
 
-  // 팔로워 목록 가져오기
+  // 팔로워 목록 가져오기 - "나를 팔로우하는 사람들"
   const fetchFollowers = async (userId: number) => {
     try {
       setIsLoadingFollows(true);
-      // 새로운 API 엔드포인트로 수정 - 닉네임과 ID를 모두 반환하는 새 엔드포인트
       const response = await fetch(
         `http://localhost:8090/api/v1/follows/${userId}/followers`,
         {
@@ -286,7 +296,7 @@ export default function OtherUserProfile() {
 
       if (response.ok) {
         const data = await response.json();
-        setFollowers(data); // 응답이 이미 {id, nickname} 형태이므로 그대로 사용
+        setFollowers(data);
       }
     } catch (error) {
       console.error("Error fetching followers:", error);
@@ -295,11 +305,10 @@ export default function OtherUserProfile() {
     }
   };
 
-  // 팔로잉 목록 가져오기
+  // 팔로잉 목록 가져오기 - "내가 팔로우하는 사람들"
   const fetchFollowings = async (userId: number) => {
     try {
       setIsLoadingFollows(true);
-      // 새로운 API 엔드포인트로 수정 - 닉네임과 ID를 모두 반환하는 새 엔드포인트
       const response = await fetch(
         `http://localhost:8090/api/v1/follows/${userId}/followings`,
         {
@@ -309,7 +318,7 @@ export default function OtherUserProfile() {
 
       if (response.ok) {
         const data = await response.json();
-        setFollowings(data); // 응답이 이미 {id, nickname} 형태이므로 그대로 사용
+        setFollowings(data);
       }
     } catch (error) {
       console.error("Error fetching followings:", error);

--- a/fe/src/app/profile/me/page.tsx
+++ b/fe/src/app/profile/me/page.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { UserInfo } from '@/types/user';
+import Image from "next/image";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { UserInfo } from "@/types/user";
 
 interface Post {
   postId: number;
@@ -25,38 +25,49 @@ export default function MyProfile() {
   const router = useRouter();
   const [userInfo, setUserInfo] = useState<UserInfo>({
     id: null,
-    nickname: '',
-    email: '',
+    nickname: "",
+    email: "",
     remainingPoint: 0,
     totalPoint: 0,
-    createdAt: null
+    createdAt: null,
   });
   const [followStats, setFollowStats] = useState({
     followers: 0,
-    following: 0
+    following: 0,
   });
   const [stats] = useState({
     detoxDays: 45,
     streakDays: 12,
     detoxTime: 32,
     completionRate: 85,
-    badges: 12
+    badges: 12,
   });
 
-  const [selectedTab, setSelectedTab] = useState('feed');
+  const [selectedTab, setSelectedTab] = useState("feed");
   const [posts, setPosts] = useState<Post[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // 팔로워/팔로잉 모달 상태
+  const [showFollowersModal, setShowFollowersModal] = useState(false);
+  const [showFollowingModal, setShowFollowingModal] = useState(false);
+  const [followers, setFollowers] = useState<
+    { id: number; nickname: string }[]
+  >([]);
+  const [followings, setFollowings] = useState<
+    { id: number; nickname: string }[]
+  >([]);
+  const [isLoadingFollows, setIsLoadingFollows] = useState(false);
 
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
-        const response = await fetch('http://localhost:8090/api/v1/users/me', {
-          credentials: 'include',
+        const response = await fetch("http://localhost:8090/api/v1/users/me", {
+          credentials: "include",
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
         });
-        
+
         if (response.ok) {
           const data = await response.json();
           setUserInfo(data);
@@ -64,12 +75,12 @@ export default function MyProfile() {
           fetchFollowStats(data.id);
           fetchUserPosts(data.id);
         } else {
-          console.error('Failed to fetch user info');
-          router.push('/login');
+          console.error("Failed to fetch user info");
+          router.push("/login");
         }
       } catch (error) {
-        console.error('Error fetching user info:', error);
-        router.push('/login');
+        console.error("Error fetching user info:", error);
+        router.push("/login");
       } finally {
         setIsLoading(false);
       }
@@ -81,12 +92,18 @@ export default function MyProfile() {
   const fetchFollowStats = async (userId: number) => {
     try {
       const [followersRes, followingRes] = await Promise.all([
-        fetch(`http://localhost:8090/api/v1/follows/${userId}/followers/number`, {
-          credentials: 'include'
-        }),
-        fetch(`http://localhost:8090/api/v1/follows/${userId}/followings/number`, {
-          credentials: 'include'
-        })
+        fetch(
+          `http://localhost:8090/api/v1/follows/${userId}/followers/number`,
+          {
+            credentials: "include",
+          }
+        ),
+        fetch(
+          `http://localhost:8090/api/v1/follows/${userId}/followings/number`,
+          {
+            credentials: "include",
+          }
+        ),
       ]);
 
       if (followersRes.ok && followingRes.ok) {
@@ -95,30 +112,35 @@ export default function MyProfile() {
         setFollowStats({ followers, following });
       }
     } catch (error) {
-      console.error('Error fetching follow stats:', error);
+      console.error("Error fetching follow stats:", error);
     }
   };
 
   const fetchUserPosts = async (userId: number) => {
     try {
-      const response = await fetch(`http://localhost:8090/api/v1/posts/user/${userId}`, {
-        credentials: 'include'
-      });
+      const response = await fetch(
+        `http://localhost:8090/api/v1/posts/user/${userId}`,
+        {
+          credentials: "include",
+        }
+      );
 
       if (response.ok) {
         const data = await response.json();
         setPosts(data);
       }
     } catch (error) {
-      console.error('Error fetching user posts:', error);
+      console.error("Error fetching user posts:", error);
     }
   };
 
   // 날짜 포맷 함수
   const formatDate = (dateString: string) => {
-    if (!dateString) return '';
+    if (!dateString) return "";
     const date = new Date(dateString);
-    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+    return `${date.getFullYear()}년 ${
+      date.getMonth() + 1
+    }월 ${date.getDate()}일`;
   };
 
   // 시간 경과 표시 함수
@@ -126,7 +148,7 @@ export default function MyProfile() {
     const date = new Date(dateString);
     const now = new Date();
     const diff = now.getTime() - date.getTime();
-    
+
     const minutes = Math.floor(diff / 60000);
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
@@ -134,7 +156,76 @@ export default function MyProfile() {
     if (days > 0) return `${days}일 전`;
     if (hours > 0) return `${hours}시간 전`;
     if (minutes > 0) return `${minutes}분 전`;
-    return '방금 전';
+    return "방금 전";
+  };
+
+  // 팔로워 목록 가져오기 - "나를 팔로우하는 사람들"
+  const fetchFollowers = async (userId: number) => {
+    try {
+      setIsLoadingFollows(true);
+      const response = await fetch(
+        `http://localhost:8090/api/v1/follows/${userId}/followers`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        setFollowers(data);
+      }
+    } catch (error) {
+      console.error("Error fetching followers:", error);
+    } finally {
+      setIsLoadingFollows(false);
+    }
+  };
+
+  // 팔로잉 목록 가져오기 - "내가 팔로우하는 사람들"
+  const fetchFollowings = async (userId: number) => {
+    try {
+      setIsLoadingFollows(true);
+      const response = await fetch(
+        `http://localhost:8090/api/v1/follows/${userId}/followings`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        setFollowings(data);
+      }
+    } catch (error) {
+      console.error("Error fetching followings:", error);
+    } finally {
+      setIsLoadingFollows(false);
+    }
+  };
+
+  // 팔로워 모달 열기
+  const handleShowFollowers = () => {
+    if (userInfo.id !== null) {
+      fetchFollowers(userInfo.id);
+      setShowFollowersModal(true);
+      setShowFollowingModal(false);
+    }
+  };
+
+  // 팔로잉 모달 열기
+  const handleShowFollowing = () => {
+    if (userInfo.id !== null) {
+      fetchFollowings(userInfo.id);
+      setShowFollowingModal(true);
+      setShowFollowersModal(false);
+    }
+  };
+
+  // 유저 프로필로 이동
+  const navigateToUserProfile = (userId: number) => {
+    setShowFollowersModal(false);
+    setShowFollowingModal(false);
+    router.push(`/profile/${userId.toString()}`);
   };
 
   if (isLoading) {
@@ -146,7 +237,7 @@ export default function MyProfile() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-4">
+    <div className="max-w-2xl mx-auto p-4 bg-white min-h-screen">
       {/* Profile Header */}
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-4">
@@ -163,40 +254,144 @@ export default function MyProfile() {
           <div>
             <h1 className="text-xl font-semibold">@{userInfo.nickname}</h1>
             <div className="flex gap-4 my-2 text-sm">
-              <div className="flex items-center gap-1">
+              <div
+                className="flex items-center gap-1 cursor-pointer hover:text-pink-500"
+                onClick={handleShowFollowers}
+              >
                 <span className="font-semibold">{followStats.followers}</span>
-                <span className="text-gray-600">팔로워</span>
+                <span className="text-gray-600 hover:text-pink-500">
+                  팔로워
+                </span>
               </div>
-              <div className="flex items-center gap-1">
+              <div
+                className="flex items-center gap-1 cursor-pointer hover:text-pink-500"
+                onClick={handleShowFollowing}
+              >
                 <span className="font-semibold">{followStats.following}</span>
-                <span className="text-gray-600">팔로잉</span>
+                <span className="text-gray-600 hover:text-pink-500">
+                  팔로잉
+                </span>
               </div>
             </div>
             <p className="text-gray-600 text-sm">{userInfo.statusMessage}</p>
-            <p className="text-gray-400 text-xs mt-1">가입일: {formatDate(userInfo.createdAt || '')}</p>
+            <p className="text-gray-400 text-xs mt-1">
+              가입일: {formatDate(userInfo.createdAt || "")}
+            </p>
           </div>
         </div>
-        <button 
-          onClick={() => router.push('/profile/me/edit')}
+        <button
+          onClick={() => router.push("/profile/me/edit")}
           className="bg-pink-500 text-white px-4 py-2 rounded-full text-sm hover:bg-pink-600 transition-colors"
         >
           프로필 설정
         </button>
       </div>
 
+      {/* 팔로워 모달 */}
+      {showFollowersModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-4 w-72 max-w-sm">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold">팔로워</h3>
+              <button
+                onClick={() => setShowFollowersModal(false)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                &times;
+              </button>
+            </div>
+            <div className="overflow-y-auto max-h-60">
+              {isLoadingFollows ? (
+                <div className="flex justify-center py-4">
+                  <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-pink-500"></div>
+                </div>
+              ) : followers.length > 0 ? (
+                <ul className="space-y-2">
+                  {followers.map((follower, index) => (
+                    <li
+                      key={index}
+                      className="py-2 px-3 hover:bg-gray-100 rounded cursor-pointer"
+                      onClick={() => navigateToUserProfile(follower.id)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
+                        <span>@{follower.nickname}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-center text-gray-500 py-4">
+                  팔로워가 없습니다.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 팔로잉 모달 */}
+      {showFollowingModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-4 w-72 max-w-sm">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold">팔로잉</h3>
+              <button
+                onClick={() => setShowFollowingModal(false)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                &times;
+              </button>
+            </div>
+            <div className="overflow-y-auto max-h-60">
+              {isLoadingFollows ? (
+                <div className="flex justify-center py-4">
+                  <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-pink-500"></div>
+                </div>
+              ) : followings.length > 0 ? (
+                <ul className="space-y-2">
+                  {followings.map((following, index) => (
+                    <li
+                      key={index}
+                      className="py-2 px-3 hover:bg-gray-100 rounded cursor-pointer"
+                      onClick={() => navigateToUserProfile(following.id)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
+                        <span>@{following.nickname}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-center text-gray-500 py-4">
+                  팔로잉하는 사용자가 없습니다.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Stats Grid */}
       <div className="grid grid-cols-3 gap-4 mb-8">
         <div className="text-center">
           <p className="text-gray-600">총 인증일수</p>
-          <p className="text-2xl font-bold text-pink-500">{stats.detoxDays}일</p>
+          <p className="text-2xl font-bold text-pink-500">
+            {stats.detoxDays}일
+          </p>
         </div>
         <div className="text-center">
-          <p className="text-gray-600">현재 스트릭</p>
-          <p className="text-2xl font-bold text-pink-500">{stats.streakDays}일</p>
+          <p className="text-gray-600">연속인증일수</p>
+          <p className="text-2xl font-bold text-pink-500">
+            {stats.streakDays}일
+          </p>
         </div>
         <div className="text-center">
           <p className="text-gray-600">현재 포인트</p>
-          <p className="text-2xl font-bold text-pink-500">{userInfo.remainingPoint} P</p>
+          <p className="text-2xl font-bold text-pink-500">
+            {userInfo.remainingPoint} P
+          </p>
         </div>
       </div>
 
@@ -208,19 +403,21 @@ export default function MyProfile() {
             <span className="text-sm text-pink-500">{stats.detoxTime}시간</span>
           </div>
           <div className="h-2 bg-gray-200 rounded-full">
-            <div 
+            <div
               className="h-full bg-pink-500 rounded-full"
-              style={{ width: `${(stats.detoxTime/48)*100}%` }}
+              style={{ width: `${(stats.detoxTime / 48) * 100}%` }}
             ></div>
           </div>
         </div>
         <div>
           <div className="flex justify-between mb-2">
             <span className="text-sm font-medium">목표 달성률</span>
-            <span className="text-sm text-pink-500">{stats.completionRate}%</span>
+            <span className="text-sm text-pink-500">
+              {stats.completionRate}%
+            </span>
           </div>
           <div className="h-2 bg-gray-200 rounded-full">
-            <div 
+            <div
               className="h-full bg-pink-500 rounded-full"
               style={{ width: `${stats.completionRate}%` }}
             ></div>
@@ -232,11 +429,16 @@ export default function MyProfile() {
       <div className="mb-8">
         <h2 className="text-lg font-semibold mb-4">획득한 뱃지</h2>
         <div className="grid grid-cols-4 gap-4">
-          {Array(stats.badges).fill(0).map((_, i) => (
-            <div key={i} className="aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
-              <span className="text-3xl">🏆</span>
-            </div>
-          ))}
+          {Array(stats.badges)
+            .fill(0)
+            .map((_, i) => (
+              <div
+                key={i}
+                className="aspect-square bg-gray-100 rounded-lg flex items-center justify-center"
+              >
+                <span className="text-3xl">🏆</span>
+              </div>
+            ))}
         </div>
       </div>
 
@@ -246,21 +448,21 @@ export default function MyProfile() {
         <div className="border-b border-gray-200 mb-4">
           <nav className="flex gap-4">
             <button
-              onClick={() => setSelectedTab('feed')}
+              onClick={() => setSelectedTab("feed")}
               className={`pb-4 px-2 ${
-                selectedTab === 'feed'
-                  ? 'border-b-2 border-pink-500 text-pink-500'
-                  : 'text-gray-500'
+                selectedTab === "feed"
+                  ? "border-b-2 border-pink-500 text-pink-500"
+                  : "text-gray-500"
               }`}
             >
               피드
             </button>
             <button
-              onClick={() => setSelectedTab('comments')}
+              onClick={() => setSelectedTab("comments")}
               className={`pb-4 px-2 ${
-                selectedTab === 'comments'
-                  ? 'border-b-2 border-pink-500 text-pink-500'
-                  : 'text-gray-500'
+                selectedTab === "comments"
+                  ? "border-b-2 border-pink-500 text-pink-500"
+                  : "text-gray-500"
               }`}
             >
               댓글
@@ -268,16 +470,23 @@ export default function MyProfile() {
           </nav>
         </div>
 
-        {selectedTab === 'feed' && (
+        {selectedTab === "feed" && (
           <div className="grid grid-cols-2 gap-4">
             {posts.length > 0 ? (
               posts.map((post) => (
-                <div key={post.postId} className="bg-white rounded-lg shadow p-4">
+                <div
+                  key={post.postId}
+                  className="bg-white rounded-lg shadow p-4"
+                >
                   <div className="flex items-center gap-2 mb-3">
                     <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
                     <div>
-                      <p className="text-sm font-medium">@{post.userNickname}</p>
-                      <p className="text-xs text-gray-500">{getTimeAgo(post.createdAt)}</p>
+                      <p className="text-sm font-medium">
+                        @{post.userNickname}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {getTimeAgo(post.createdAt)}
+                      </p>
                     </div>
                   </div>
                   <div className="aspect-video bg-gray-100 rounded-lg mb-3"></div>
@@ -285,17 +494,21 @@ export default function MyProfile() {
                 </div>
               ))
             ) : (
-              <p className="text-gray-500 col-span-2 text-center py-8">아직 작성한 글이 없습니다.</p>
+              <p className="text-gray-500 col-span-2 text-center py-8">
+                아직 작성한 글이 없습니다.
+              </p>
             )}
           </div>
         )}
 
-        {selectedTab === 'comments' && (
+        {selectedTab === "comments" && (
           <div className="space-y-4">
-            <p className="text-gray-500 text-center py-8">아직 작성한 댓글이 없습니다.</p>
+            <p className="text-gray-500 text-center py-8">
+              아직 작성한 댓글이 없습니다.
+            </p>
           </div>
         )}
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
🧠 Feature PR
새로운 기능을 추가하는 PR입니다.


📝 PR 제목 규칙
❝ [FEAT] 대상 - 추가 기능 - #이슈번호 ❞

( 예: ❛ [FEAT] PostService - 게시글 생성 기능 추가 - https://github.com/Dopamine-Detoxx/Brain-Cleaner/issues/13 ❜ )

✒️ 
[FEAT] FE - 프로필페이지 - 팔로우/언팔로우 be연동, 팔로워/팔로잉 목록 모달형식으로 열람 가능, 각 유저 닉네임 클릭시 프로필창으로 넘어가는 기능 구현중 -> 완료

✒️ 
[FIX] BE - 팔로워/팔로잉 목록 보여주는 기능 백엔드 코드수정(완료), FE - 프로필페이지 팔로워/팔로잉 목록 보여주는기능 be와 연결완료

.

1️⃣관련 이슈
이슈 링크 달아주세요.

🔗

https://github.com/Dopamine-Detoxx/Brain-Cleaner/issues/114


.
2️⃣작업 내용
어떤 기능을 구현했는지 간단히 설명

✒️
**FE**

- 다른 유저의 프로필창에 있는 팔로우 버튼을 통해 팔로우 가능

- 이미 팔로우 하고있는 사람은 버튼이 '언팔로우'로 되어있고, 언팔로우 버튼을 누르면 팔로우 해제 가능

- 해당 유저의 팔로우/팔로잉 목록을 조회할 수 있고, 목록의 닉네임을 누르면 해당 유저의 프로필 페이지로 이동 가능

- 위 기능은 내 프로필 페이지에서도 가능

. 

**BE**


- service의 언팔로우 메서드 @DeleteMapping경로 수정(/{followerId}/{followingId}  =>  a가 b를 언팔로우)


- id, nickname만을 담고있는 Dto클래스 추가(기존엔 유저의 닉네임만을 받아오고 있었는데, 닉네임을 누르면 해당 유저의 프로필 페이지로 이동하게 하기위해 id값도 필요)

.

3️⃣테스트
[ ]안에 x를 넣으시면 체크가 됩니다.

 로컬에서 테스트 완료 🧪🫧



