### PR TITLE
[FEAT ] FE - 프로필 페이지 - '총 인증일수', '연속인증일수', '디톡스시간' 반영 / 프로필 페이지의 게시글 …

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fe",
       "version": "0.1.0",
+      "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
@@ -6090,6 +6091,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -723,20 +723,31 @@ export default function Home() {
                 </div>
               ) : user ? (
                 <div className="flex flex-col items-center">
-                  <Link href={`/profile/${user.id}`}>
+                  <Link href={`/profile/me`}>
                     <div className="rounded-full bg-pink-100 border-4 border-pink-200 p-4 mb-3 cursor-pointer">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-10 w-10 text-gray-700"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                          clipRule="evenodd"
+                      {user.profileImage ? (
+                        <Image
+                          src={user.profileImage}
+                          alt={`${user.nickname}의 프로필`}
+                          width={40}
+                          height={40}
+                          className="rounded-full w-10 h-10 object-cover"
+                          unoptimized={true}
                         />
-                      </svg>
+                      ) : (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-10 w-10 text-gray-700"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      )}
                     </div>
                   </Link>
                   <Link

--- a/fe/src/app/profile/[id]/page.tsx
+++ b/fe/src/app/profile/[id]/page.tsx
@@ -1,9 +1,10 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import { useState, useEffect } from 'react';
-import { useRouter, useParams } from 'next/navigation';
-import { UserInfo } from '@/types/user';
+import Image from "next/image";
+import { useState, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { UserInfo } from "@/types/user";
+import CommentModal from "@/components/CommentModal";
 
 interface Post {
   postId: number;
@@ -19,17 +20,18 @@ interface Post {
   detoxTime: number | null;
   createdAt: string;
   updatedAt: string;
+  commentCount?: number;
 }
 
-const CUSTOM_PINK = '#F742CD';
+const CUSTOM_PINK = "#F742CD";
 
 const BADGES = [
-  { name: '디톡스새싹', requiredPoints: 0, emoji: '🌱' },
-  { name: '절제수련생', requiredPoints: 100, emoji: '🧘' },
-  { name: '집중탐험가', requiredPoints: 600, emoji: '🔍' },
-  { name: '선명한의식', requiredPoints: 2000, emoji: '✨' },
-  { name: '도파민파괴자', requiredPoints: 4500, emoji: '💥' },
-  { name: '브레인클리너', requiredPoints: 7500, emoji: '🧠' },
+  { name: "디톡스새싹", requiredPoints: 0, emoji: "🌱" },
+  { name: "절제수련생", requiredPoints: 100, emoji: "🧘" },
+  { name: "집중탐험가", requiredPoints: 600, emoji: "🔍" },
+  { name: "선명한의식", requiredPoints: 2000, emoji: "✨" },
+  { name: "도파민파괴자", requiredPoints: 4500, emoji: "💥" },
+  { name: "브레인클리너", requiredPoints: 7500, emoji: "🧠" },
 ];
 
 export default function OtherUserProfile() {
@@ -39,25 +41,25 @@ export default function OtherUserProfile() {
   const [isFollowing, setIsFollowing] = useState(false);
   const [userInfo, setUserInfo] = useState<UserInfo>({
     id: null,
-    nickname: '',
-    email: '',
+    nickname: "",
+    email: "",
     remainingPoint: 0,
     totalPoint: 0,
     createdAt: null,
-    statusMessage: '',
+    statusMessage: "",
   });
   const [followStats, setFollowStats] = useState({
     followers: 0,
     following: 0,
   });
-  const [stats] = useState({
-    detoxDays: 45,
-    streakDays: 12,
-    detoxTime: 32,
-    badges: 8,
+  const [stats, setStats] = useState({
+    detoxDays: 0,
+    streakDays: 0,
+    detoxTime: 0,
+    completionRate: 0,
   });
 
-  const [selectedTab, setSelectedTab] = useState('feed');
+  const [selectedTab, setSelectedTab] = useState("feed");
   const [posts, setPosts] = useState<Post[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -72,70 +74,44 @@ export default function OtherUserProfile() {
   >([]);
   const [isLoadingFollows, setIsLoadingFollows] = useState(false);
 
+  // CommentModal 관련 상태
+  const [selectedPost, setSelectedPost] = useState<Post | null>(null);
+  const [showCommentModal, setShowCommentModal] = useState(false);
+
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
         setIsLoading(true);
-        // 먼저 현재 로그인한 사용자 정보를 가져와서 본인 프로필인지 확인
-        const meResponse = await fetch(
-          'http://localhost:8090/api/v1/users/me',
-          {
-            credentials: 'include',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-
-        if (meResponse.ok) {
-          const meData = await meResponse.json();
-          // 본인 프로필이면 /profile/me로 리다이렉트
-          if (meData.id.toString() === userId) {
-            router.push('/profile/me');
-            return;
-          }
-
-          // 팔로우 상태 확인 - 주석 해제하고 구현
-          const followStatusResponse = await fetch(
-            `http://localhost:8090/api/v1/follows/check?followerId=${meData.id}&followingId=${userId}`,
-            {
-              credentials: 'include',
-            }
-          );
-          if (followStatusResponse.ok) {
-            const followStatus = await followStatusResponse.json();
-            setIsFollowing(followStatus);
-          }
-        }
-
-        // 요청된 사용자의 프로필 정보 가져오기
         const response = await fetch(
           `http://localhost:8090/api/v1/users/${userId}`,
           {
-            credentials: 'include',
+            credentials: "include",
             headers: {
-              'Content-Type': 'application/json',
+              "Content-Type": "application/json",
             },
           }
         );
 
         if (response.ok) {
           const data = await response.json();
-          // profileImageUrl을 profileImage로 매핑
+          console.log("프로필 데이터 로드:", data);
           const userData = {
             ...data,
             profileImage: data.profileImageUrl,
           };
           setUserInfo(userData);
-          // 사용자 정보를 가져온 후 팔로워/팔로잉 수와 게시글을 가져옴
           fetchFollowStats(data.id);
           fetchUserPosts(data.id);
+          fetchVerificationStats(data.id);
+
+          // 팔로우 상태 확인 (나를 기준으로 해당 사용자를 팔로우하고 있는지)
+          checkFollowStatus(data.id);
         } else {
-          console.error('Failed to fetch user info');
-          router.push('/404'); // 사용자를 찾을 수 없는 경우 404 페이지로 이동
+          console.error("프로필 정보를 불러오는데 실패했습니다.");
+          router.push("/404"); // 사용자를 찾을 수 없는 경우 404 페이지로 이동
         }
       } catch (error) {
-        console.error('Error fetching user info:', error);
+        console.error("Error fetching user info:", error);
       } finally {
         setIsLoading(false);
       }
@@ -152,13 +128,13 @@ export default function OtherUserProfile() {
         fetch(
           `http://localhost:8090/api/v1/follows/${userId}/followers/number`,
           {
-            credentials: 'include',
+            credentials: "include",
           }
         ),
         fetch(
           `http://localhost:8090/api/v1/follows/${userId}/followings/number`,
           {
-            credentials: 'include',
+            credentials: "include",
           }
         ),
       ]);
@@ -169,7 +145,7 @@ export default function OtherUserProfile() {
         setFollowStats({ followers, following });
       }
     } catch (error) {
-      console.error('Error fetching follow stats:', error);
+      console.error("Error fetching follow stats:", error);
     }
   };
 
@@ -178,7 +154,7 @@ export default function OtherUserProfile() {
       const response = await fetch(
         `http://localhost:8090/api/v1/posts/user/${userId}`,
         {
-          credentials: 'include',
+          credentials: "include",
         }
       );
 
@@ -187,22 +163,22 @@ export default function OtherUserProfile() {
         setPosts(data);
       }
     } catch (error) {
-      console.error('Error fetching user posts:', error);
+      console.error("Error fetching user posts:", error);
     }
   };
 
   const handleFollowToggle = async () => {
     try {
       // 현재 로그인한 사용자 정보 가져오기
-      const meResponse = await fetch('http://localhost:8090/api/v1/users/me', {
-        credentials: 'include',
+      const meResponse = await fetch("http://localhost:8090/api/v1/users/me", {
+        credentials: "include",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
       });
 
       if (!meResponse.ok) {
-        console.error('Failed to fetch current user info');
+        console.error("Failed to fetch current user info");
         return;
       }
 
@@ -213,10 +189,10 @@ export default function OtherUserProfile() {
         const unfollowResponse = await fetch(
           `http://localhost:8090/api/v1/follows/${meData.id}/${userInfo.id}`,
           {
-            method: 'DELETE',
-            credentials: 'include',
+            method: "DELETE",
+            credentials: "include",
             headers: {
-              'Content-Type': 'application/json',
+              "Content-Type": "application/json",
             },
           }
         );
@@ -236,18 +212,18 @@ export default function OtherUserProfile() {
       } else {
         // 팔로우 로직
         // API 엔드포인트 확인 - "/api/v1/follows"로 POST 요청
-        console.log('Sending follow request:', {
+        console.log("Sending follow request:", {
           followerId: meData.id,
           followingId: userInfo.id,
         });
 
         const followResponse = await fetch(
-          'http://localhost:8090/api/v1/follows',
+          "http://localhost:8090/api/v1/follows",
           {
-            method: 'POST',
-            credentials: 'include',
+            method: "POST",
+            credentials: "include",
             headers: {
-              'Content-Type': 'application/json',
+              "Content-Type": "application/json",
             },
             body: JSON.stringify({
               followerId: meData.id,
@@ -270,7 +246,7 @@ export default function OtherUserProfile() {
         }
       }
     } catch (error) {
-      console.error('Error toggling follow status:', error);
+      console.error("Error toggling follow status:", error);
     }
   };
 
@@ -287,7 +263,7 @@ export default function OtherUserProfile() {
     if (days > 0) return `${days}일 전`;
     if (hours > 0) return `${hours}시간 전`;
     if (minutes > 0) return `${minutes}분 전`;
-    return '방금 전';
+    return "방금 전";
   };
 
   // 팔로워 목록 가져오기 - "나를 팔로우하는 사람들"
@@ -297,7 +273,7 @@ export default function OtherUserProfile() {
       const response = await fetch(
         `http://localhost:8090/api/v1/follows/${userId}/followers`,
         {
-          credentials: 'include',
+          credentials: "include",
         }
       );
 
@@ -306,7 +282,7 @@ export default function OtherUserProfile() {
         setFollowers(data);
       }
     } catch (error) {
-      console.error('Error fetching followers:', error);
+      console.error("Error fetching followers:", error);
     } finally {
       setIsLoadingFollows(false);
     }
@@ -319,7 +295,7 @@ export default function OtherUserProfile() {
       const response = await fetch(
         `http://localhost:8090/api/v1/follows/${userId}/followings`,
         {
-          credentials: 'include',
+          credentials: "include",
         }
       );
 
@@ -328,7 +304,7 @@ export default function OtherUserProfile() {
         setFollowings(data);
       }
     } catch (error) {
-      console.error('Error fetching followings:', error);
+      console.error("Error fetching followings:", error);
     } finally {
       setIsLoadingFollows(false);
     }
@@ -359,6 +335,121 @@ export default function OtherUserProfile() {
     router.push(`/profile/${userId.toString()}`);
   };
 
+  // CommentModal 관련 함수
+  const handlePostClick = (post: Post) => {
+    setSelectedPost(post);
+    setShowCommentModal(true);
+  };
+
+  const handleCloseCommentModal = () => {
+    setShowCommentModal(false);
+    setSelectedPost(null);
+  };
+
+  const handleCommentUpdate = (count: number) => {
+    if (!selectedPost) return;
+
+    // selectedPost의 댓글 수 업데이트
+    setSelectedPost({
+      ...selectedPost,
+      commentCount: count,
+    });
+
+    // posts 배열 내의 해당 게시글 댓글 수도 업데이트
+    setPosts((prev) =>
+      prev.map((post) =>
+        post.postId === selectedPost.postId
+          ? { ...post, commentCount: count }
+          : post
+      )
+    );
+  };
+
+  // 인증 관련 정보를 가져오는 함수 추가
+  const fetchVerificationStats = async (userId: number) => {
+    try {
+      // 1. 연속 인증일수 가져오기
+      const streakResponse = await fetch(
+        `http://localhost:8090/api/v1/verifications/streak/${userId}`,
+        {
+          credentials: "include",
+        }
+      );
+
+      let streakDays = 0;
+      if (streakResponse.ok) {
+        streakDays = await streakResponse.json();
+      }
+
+      // 2. 인증 게시글만 필터링하여 가져오기 (categoryId가 3인 게시글만)
+      const verificationPostsResponse = await fetch(
+        `http://localhost:8090/api/v1/posts/user/${userId}?categoryId=3`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (verificationPostsResponse.ok) {
+        const verificationPosts = await verificationPostsResponse.json();
+
+        // 총 인증일수 = 인증 게시글 수
+        const totalVerificationDays = verificationPosts.length;
+
+        // 디톡스 시간 계산 - 모든 인증 게시글의 detoxTime 합산
+        let totalDetoxTime = 0;
+        verificationPosts.forEach((post: Post) => {
+          if (post.detoxTime) {
+            totalDetoxTime += post.detoxTime;
+          }
+        });
+
+        // stats 상태 업데이트
+        setStats({
+          detoxDays: totalVerificationDays,
+          streakDays: streakDays,
+          detoxTime: totalDetoxTime,
+          completionRate: 0,
+        });
+      }
+    } catch (error) {
+      console.error("Error fetching verification stats:", error);
+    }
+  };
+
+  // 팔로우 상태 확인 함수 추가
+  const checkFollowStatus = async (profileUserId: number) => {
+    try {
+      // 현재 로그인한 사용자 정보 가져오기
+      const meResponse = await fetch("http://localhost:8090/api/v1/users/me", {
+        credentials: "include",
+      });
+
+      if (meResponse.ok) {
+        const meData = await meResponse.json();
+
+        // 자신의 프로필이면 팔로우 상태 확인할 필요 없음
+        if (meData.id === profileUserId) {
+          return;
+        }
+
+        // 팔로우 상태 확인 API 호출
+        const followStatusResponse = await fetch(
+          `http://localhost:8090/api/v1/follows/status/${meData.id}/${profileUserId}`,
+          {
+            credentials: "include",
+          }
+        );
+
+        if (followStatusResponse.ok) {
+          const isFollowing = await followStatusResponse.json();
+          setIsFollowing(isFollowing);
+        }
+      }
+    } catch (error) {
+      console.error("Error checking follow status:", error);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center min-h-screen bg-white">
@@ -373,14 +464,16 @@ export default function OtherUserProfile() {
         {/* Header with username and follow button */}
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold">{userInfo.nickname}</h1>
+
+          {/* 항상 팔로우 버튼만 표시 */}
           <button
             onClick={handleFollowToggle}
             className={`w-20 text-white px-3 py-1.5 rounded-md text-sm hover:opacity-90 transition-colors ${
-              isFollowing ? 'bg-gray-400' : ''
+              isFollowing ? "bg-gray-400" : ""
             }`}
             style={{ backgroundColor: isFollowing ? undefined : CUSTOM_PINK }}
           >
-            {isFollowing ? '팔로잉' : '팔로우'}
+            {isFollowing ? "팔로잉" : "팔로우"}
           </button>
         </div>
 
@@ -389,13 +482,17 @@ export default function OtherUserProfile() {
           <div className="flex flex-col items-center gap-4">
             {/* Profile Image */}
             <div className="relative">
-              <Image
-                src={userInfo.profileImage || '/placeholder-avatar.png'}
-                alt="Profile"
-                width={80}
-                height={80}
-                className="rounded-full object-cover"
-              />
+              <div className="w-20 h-20 rounded-full overflow-hidden">
+                <div className="w-full h-full relative">
+                  <Image
+                    src={userInfo.profileImage || "/placeholder-avatar.png"}
+                    alt="Profile"
+                    fill
+                    style={{ objectFit: "cover" }}
+                    unoptimized={true}
+                  />
+                </div>
+              </div>
               <div
                 className="absolute bottom-0 right-0 w-4 h-4 rounded-full border-2 border-white"
                 style={{ backgroundColor: CUSTOM_PINK }}
@@ -415,7 +512,7 @@ export default function OtherUserProfile() {
           <div className="w-[16rem]">
             <div className="grid grid-cols-3 text-center">
               <div>
-                <div className="font-semibold text-lg">{stats.detoxDays}</div>
+                <div className="font-semibold text-lg">{posts.length}</div>
                 <div className="text-sm text-gray-500">게시물</div>
               </div>
               <div className="cursor-pointer" onClick={handleShowFollowers}>
@@ -448,7 +545,7 @@ export default function OtherUserProfile() {
                 >
                   <div
                     className={`w-12 h-12 rounded-full flex items-center justify-center ${
-                      isEarned ? 'bg-gray-100' : 'bg-gray-50 opacity-30'
+                      isEarned ? "bg-gray-100" : "bg-gray-50 opacity-30"
                     }`}
                   >
                     <span className="text-lg">{badge.emoji}</span>
@@ -456,7 +553,7 @@ export default function OtherUserProfile() {
                   <span
                     className="text-xs mt-1 text-center"
                     style={{
-                      color: isEarned ? CUSTOM_PINK : 'rgb(107 114 128)',
+                      color: isEarned ? CUSTOM_PINK : "rgb(107 114 128)",
                     }}
                   >
                     {badge.name}
@@ -472,40 +569,40 @@ export default function OtherUserProfile() {
           <div className="border-b border-gray-200 mb-8">
             <nav className="flex justify-center">
               <button
-                onClick={() => setSelectedTab('feed')}
+                onClick={() => setSelectedTab("feed")}
                 className={`pb-4 px-8 w-40 text-center ${
-                  selectedTab === 'feed'
+                  selectedTab === "feed"
                     ? `border-b-2 border-[${CUSTOM_PINK}]`
-                    : 'text-gray-500'
+                    : "text-gray-500"
                 }`}
                 style={{
-                  color: selectedTab === 'feed' ? CUSTOM_PINK : undefined,
+                  color: selectedTab === "feed" ? CUSTOM_PINK : undefined,
                 }}
               >
                 피드
               </button>
               <button
-                onClick={() => setSelectedTab('comments')}
+                onClick={() => setSelectedTab("comments")}
                 className={`pb-4 px-8 w-40 text-center ${
-                  selectedTab === 'comments'
+                  selectedTab === "comments"
                     ? `border-b-2 border-[${CUSTOM_PINK}]`
-                    : 'text-gray-500'
+                    : "text-gray-500"
                 }`}
                 style={{
-                  color: selectedTab === 'comments' ? CUSTOM_PINK : undefined,
+                  color: selectedTab === "comments" ? CUSTOM_PINK : undefined,
                 }}
               >
                 댓글
               </button>
               <button
-                onClick={() => setSelectedTab('stats')}
+                onClick={() => setSelectedTab("stats")}
                 className={`pb-4 px-8 w-40 text-center ${
-                  selectedTab === 'stats'
+                  selectedTab === "stats"
                     ? `border-b-2 border-[${CUSTOM_PINK}]`
-                    : 'text-gray-500'
+                    : "text-gray-500"
                 }`}
                 style={{
-                  color: selectedTab === 'stats' ? CUSTOM_PINK : undefined,
+                  color: selectedTab === "stats" ? CUSTOM_PINK : undefined,
                 }}
               >
                 디톡스정보
@@ -513,11 +610,15 @@ export default function OtherUserProfile() {
             </nav>
           </div>
 
-          {selectedTab === 'feed' && (
+          {selectedTab === "feed" && (
             <div className="grid grid-cols-2 gap-4">
               {posts.length > 0 ? (
                 posts.map((post) => (
-                  <div key={post.postId} className="border rounded-lg p-4">
+                  <div
+                    key={post.postId}
+                    className="border rounded-lg p-4 cursor-pointer hover:shadow-md transition-shadow"
+                    onClick={() => handlePostClick(post)}
+                  >
                     <div className="flex items-center gap-2 mb-3">
                       <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
                       <div>
@@ -541,7 +642,14 @@ export default function OtherUserProfile() {
                       </div>
                     )}
                     <h3 className="font-medium mb-1">{post.title}</h3>
-                    <p className="text-sm text-gray-600">{post.content}</p>
+                    <p className="text-sm text-gray-600 line-clamp-2">
+                      {post.content}
+                    </p>
+                    <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
+                      <span>조회 {post.viewCount || 0}</span>
+                      <span>좋아요 {post.likeCount || 0}</span>
+                      <span>댓글 {post.commentCount || 0}</span>
+                    </div>
                   </div>
                 ))
               ) : (
@@ -552,7 +660,7 @@ export default function OtherUserProfile() {
             </div>
           )}
 
-          {selectedTab === 'comments' && (
+          {selectedTab === "comments" && (
             <div className="space-y-4">
               <p className="text-gray-500 text-center py-8">
                 아직 작성한 댓글이 없습니다.
@@ -560,7 +668,7 @@ export default function OtherUserProfile() {
             </div>
           )}
 
-          {selectedTab === 'stats' && (
+          {selectedTab === "stats" && (
             <div className="max-w-[16rem] mx-auto">
               <div className="space-y-3">
                 <div className="flex items-center justify-between text-sm">
@@ -601,11 +709,47 @@ export default function OtherUserProfile() {
                     ></div>
                   </div>
                 </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-gray-600">목표 달성률</span>
+                    <span
+                      className="font-medium"
+                      style={{ color: CUSTOM_PINK }}
+                    >
+                      {stats.completionRate}%
+                    </span>
+                  </div>
+                  <div className="h-2 bg-gray-100 rounded-full">
+                    <div
+                      className="h-full rounded-full transition-all duration-300"
+                      style={{
+                        width: `${stats.completionRate}%`,
+                        backgroundColor: CUSTOM_PINK,
+                      }}
+                    ></div>
+                  </div>
+                </div>
               </div>
             </div>
           )}
         </div>
       </div>
+
+      {/* CommentModal */}
+      {showCommentModal && selectedPost && (
+        <CommentModal
+          postId={selectedPost.postId}
+          onClose={handleCloseCommentModal}
+          postImage={selectedPost.imageUrl}
+          postContent={selectedPost.content}
+          userNickname={selectedPost.userNickname}
+          createdAt={selectedPost.createdAt}
+          isOwnPost={userInfo.id === selectedPost.userId}
+          onUpdate={handleCommentUpdate}
+          detoxTime={selectedPost.detoxTime ?? undefined}
+          userId={selectedPost.userId}
+        />
+      )}
     </div>
   );
 }

--- a/fe/src/components/Post.tsx
+++ b/fe/src/components/Post.tsx
@@ -8,6 +8,7 @@ import {
   fetchPurchasedEmojis,
   Emoji,
 } from "@/utils/emojiUtils";
+import { getProfilePath } from "@/utils/profileHelpers";
 
 export interface PostProps {
   postId: number;
@@ -333,7 +334,7 @@ export default function Post({
   return (
     <div className="p-5" ref={postRef}>
       <div className="flex items-start mb-3">
-        <Link href={`/profile/${userId}`}>
+        <Link href={getProfilePath(user, userId)}>
           <div className="mr-3 cursor-pointer relative w-8 h-8">
             {profileImage ? (
               <Image
@@ -365,7 +366,7 @@ export default function Post({
         <div className="flex-1">
           <div className="flex justify-between items-start mb-2">
             <div className="flex items-center gap-1.5">
-              <Link href={`/profile/${userId}`}>
+              <Link href={getProfilePath(user, userId)}>
                 <span className="font-bold text-[14px] text-gray-900 cursor-pointer hover:text-pink-500">
                   {userNickname}
                 </span>

--- a/fe/src/contexts/UserContext.tsx
+++ b/fe/src/contexts/UserContext.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import {
   createContext,
@@ -6,8 +6,8 @@ import {
   useState,
   useEffect,
   ReactNode,
-} from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+} from "react";
+import { usePathname, useRouter } from "next/navigation";
 
 export interface User {
   id: number;
@@ -18,6 +18,12 @@ export interface User {
   role?: string;
   isSocialUser?: boolean;
   profileImage?: string;
+}
+
+interface Post {
+  postId: number;
+  detoxTime: number | null;
+  // 필요한 다른 필드들
 }
 
 interface UserContextType {
@@ -38,30 +44,41 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
 
+  // 하드코딩된 상태 대신 초기값을 0으로 설정
+  const [stats, setStats] = useState({
+    detoxDays: 0, // 총 인증일수 - 인증 게시글 갯수로 변경
+    streakDays: 0, // 연속 인증일수 - 백엔드 API에서 가져옴
+    detoxTime: 0, // 디톡스 시간 - 인증 게시글의 detoxTime 합산
+    completionRate: 85, // 목표 달성률은 그대로 유지
+  });
+
   // fetchUserInfo 함수 (refreshUserInfo 에서 사용될 수 있음)
   const fetchUserInfo = async () => {
-    console.log('[UserContext:fetchUserInfo] 시작'); // 로그 추가
+    console.log("[UserContext:fetchUserInfo] 시작"); // 로그 추가
     try {
-      console.log('[UserContext:fetchUserInfo] setLoading(true) 호출 전');
+      console.log("[UserContext:fetchUserInfo] setLoading(true) 호출 전");
       setLoading(true);
       console.log(
-        '[UserContext:fetchUserInfo] setLoading(true) 호출 후, loading 상태:',
+        "[UserContext:fetchUserInfo] setLoading(true) 호출 후, loading 상태:",
         true
       ); // 로그 추가
 
-      console.log('[UserContext:fetchUserInfo] /api/v1/users/me 호출 시작'); // 로그 추가
-      const response = await fetch('http://localhost:8090/api/v1/users/me', {
-        credentials: 'include',
+      console.log("[UserContext:fetchUserInfo] /api/v1/users/me 호출 시작"); // 로그 추가
+      const response = await fetch("http://localhost:8090/api/v1/users/me", {
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
       });
       console.log(
-        '[UserContext:fetchUserInfo] /api/v1/users/me 응답 상태:',
+        "[UserContext:fetchUserInfo] /api/v1/users/me 응답 상태:",
         response.status
       ); // 로그 추가
 
       if (response.ok) {
         const data = await response.json();
         console.log(
-          '[UserContext:fetchUserInfo] /api/v1/users/me 성공. 데이터:',
+          "[UserContext:fetchUserInfo] /api/v1/users/me 성공. 데이터:",
           data
         ); // 로그 추가
 
@@ -72,51 +89,55 @@ export function UserProvider({ children }: { children: ReactNode }) {
         };
 
         console.log(
-          '[UserContext:fetchUserInfo] setUser(data) 호출 전. data:',
+          "[UserContext:fetchUserInfo] setUser(data) 호출 전. data:",
           userData
         ); // 로그 추가
         setUser(userData);
         console.log(
-          '[UserContext:fetchUserInfo] setUser(data) 호출 후. user 상태:',
+          "[UserContext:fetchUserInfo] setUser(data) 호출 후. user 상태:",
           userData
         ); // 로그 추가
 
         // 추가 정보도 로컬 스토리지에 저장
-        localStorage.setItem('userId', data.id.toString());
-        localStorage.setItem('nickname', data.nickname);
-        localStorage.setItem('email', data.email);
-        localStorage.setItem('isLoggedIn', 'true');
-        console.log('[UserContext:fetchUserInfo] localStorage 업데이트 완료'); // 로그 추가
+        localStorage.setItem("userId", data.id.toString());
+        localStorage.setItem("nickname", data.nickname);
+        localStorage.setItem("email", data.email);
+        localStorage.setItem("isLoggedIn", "true");
+        console.log("[UserContext:fetchUserInfo] localStorage 업데이트 완료"); // 로그 추가
 
         setError(null);
+
+        if (data.id) {
+          fetchVerificationStats(data.id);
+        }
       } else {
-        console.log('[UserContext:fetchUserInfo] /api/v1/users/me 실패.'); // 로그 추가
-        console.log('[UserContext:fetchUserInfo] setUser(null) 호출 전'); // 로그 추가
+        console.log("[UserContext:fetchUserInfo] /api/v1/users/me 실패."); // 로그 추가
+        console.log("[UserContext:fetchUserInfo] setUser(null) 호출 전"); // 로그 추가
         setUser(null);
         console.log(
-          '[UserContext:fetchUserInfo] setUser(null) 호출 후. user 상태:',
+          "[UserContext:fetchUserInfo] setUser(null) 호출 후. user 상태:",
           null
         ); // 로그 추가
-        localStorage.removeItem('isLoggedIn');
-        setError('사용자 정보를 가져오는데 실패했습니다.');
+        localStorage.removeItem("isLoggedIn");
+        setError("사용자 정보를 가져오는데 실패했습니다.");
       }
     } catch (error) {
-      console.error('[UserContext:fetchUserInfo] 오류 발생:', error); // 로그 추가
-      console.log('[UserContext:fetchUserInfo] 오류 - setUser(null) 호출 전'); // 로그 추가
+      console.error("[UserContext:fetchUserInfo] 오류 발생:", error); // 로그 추가
+      console.log("[UserContext:fetchUserInfo] 오류 - setUser(null) 호출 전"); // 로그 추가
       setUser(null);
       console.log(
-        '[UserContext:fetchUserInfo] 오류 - setUser(null) 호출 후. user 상태:',
+        "[UserContext:fetchUserInfo] 오류 - setUser(null) 호출 후. user 상태:",
         null
       ); // 로그 추가
-      localStorage.removeItem('isLoggedIn'); // 오류 시에도 로그인 상태 제거
-      setError('인증 과정에서 오류가 발생했습니다.');
+      localStorage.removeItem("isLoggedIn"); // 오류 시에도 로그인 상태 제거
+      setError("인증 과정에서 오류가 발생했습니다.");
     } finally {
       console.log(
-        '[UserContext:fetchUserInfo] finally 블록 시작. setLoading(false) 호출 전'
+        "[UserContext:fetchUserInfo] finally 블록 시작. setLoading(false) 호출 전"
       ); // 로그 추가
       setLoading(false);
       console.log(
-        '[UserContext:fetchUserInfo] finally 블록 - setLoading(false) 호출 후. loading 상태:',
+        "[UserContext:fetchUserInfo] finally 블록 - setLoading(false) 호출 후. loading 상태:",
         false
       ); // 로그 추가
     }
@@ -124,44 +145,44 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
   // 사용자 정보 새로고침 함수
   const refreshUserInfo = async () => {
-    console.log('[UserContext:refreshUserInfo] 호출됨'); // 로그 추가
+    console.log("[UserContext:refreshUserInfo] 호출됨"); // 로그 추가
     await fetchUserInfo();
   };
 
   // 로그아웃 함수
   const logout = async () => {
     try {
-      console.log('[UserContext:logout] 시작'); // 로그 추가
+      console.log("[UserContext:logout] 시작"); // 로그 추가
       const response = await fetch(
-        'http://localhost:8090/api/v1/users/logout',
+        "http://localhost:8090/api/v1/users/logout",
         {
-          method: 'POST',
-          credentials: 'include',
+          method: "POST",
+          credentials: "include",
         }
       );
       console.log(
-        '[UserContext:logout] 로그아웃 API 응답 상태:',
+        "[UserContext:logout] 로그아웃 API 응답 상태:",
         response.status
       ); // 로그 추가
 
       localStorage.clear();
       sessionStorage.clear();
       console.log(
-        '[UserContext:logout] localStorage/sessionStorage 클리어 완료'
+        "[UserContext:logout] localStorage/sessionStorage 클리어 완료"
       ); // 로그 추가
 
-      console.log('[UserContext:logout] setUser(null) 호출 전'); // 로그 추가
+      console.log("[UserContext:logout] setUser(null) 호출 전"); // 로그 추가
       setUser(null);
       console.log(
-        '[UserContext:logout] setUser(null) 호출 후. user 상태:',
+        "[UserContext:logout] setUser(null) 호출 후. user 상태:",
         null
       ); // 로그 추가
 
-      router.push('/');
-      console.log('[UserContext:logout] 홈으로 리다이렉트 완료'); // 로그 추가
+      router.push("/");
+      console.log("[UserContext:logout] 홈으로 리다이렉트 완료"); // 로그 추가
     } catch (error) {
-      console.error('[UserContext:logout] 로그아웃 중 오류:', error); // 로그 추가
-      setError('로그아웃 중 오류가 발생했습니다.');
+      console.error("[UserContext:logout] 로그아웃 중 오류:", error); // 로그 추가
+      setError("로그아웃 중 오류가 발생했습니다.");
     }
   };
 
@@ -170,27 +191,27 @@ export function UserProvider({ children }: { children: ReactNode }) {
     console.log(`[UserContext:useEffect] 시작. Pathname: ${pathname}`); // 로그 추가
 
     const checkAuth = async () => {
-      console.log('[UserContext:useEffect:checkAuth] 시작');
+      console.log("[UserContext:useEffect:checkAuth] 시작");
       try {
         console.log(
-          '[UserContext:useEffect:checkAuth] setLoading(true) 호출 전'
+          "[UserContext:useEffect:checkAuth] setLoading(true) 호출 전"
         );
         setLoading(true);
         console.log(
-          '[UserContext:useEffect:checkAuth] setLoading(true) 호출 후, loading 상태:',
+          "[UserContext:useEffect:checkAuth] setLoading(true) 호출 후, loading 상태:",
           true
         ); // 로그 추가
 
         const urlParams = new URLSearchParams(window.location.search);
-        const isSocialLogin = urlParams.get('social') === 'true';
-        const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
+        const isSocialLogin = urlParams.get("social") === "true";
+        const isLoggedIn = localStorage.getItem("isLoggedIn") === "true";
         console.log(
           `[UserContext:useEffect:checkAuth] 소셜로그인 감지: ${isSocialLogin}, 로컬로그인상태: ${isLoggedIn}`
         ); // 로그 추가
 
         if (isSocialLogin) {
           console.log(
-            '[UserContext:useEffect:checkAuth] 소셜 로그인 처리 시작 (URL 파라미터 제거)'
+            "[UserContext:useEffect:checkAuth] 소셜 로그인 처리 시작 (URL 파라미터 제거)"
           ); // 로그 추가
           window.history.replaceState(
             {},
@@ -201,23 +222,23 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
         if (isSocialLogin || isLoggedIn) {
           console.log(
-            '[UserContext:useEffect:checkAuth] 로그인 상태 확인됨. /api/v1/users/me 호출 시작'
+            "[UserContext:useEffect:checkAuth] 로그인 상태 확인됨. /api/v1/users/me 호출 시작"
           ); // 로그 추가
           const response = await fetch(
-            'http://localhost:8090/api/v1/users/me',
+            "http://localhost:8090/api/v1/users/me",
             {
-              credentials: 'include',
+              credentials: "include",
             }
           );
           console.log(
-            '[UserContext:useEffect:checkAuth] /api/v1/users/me 응답 상태:',
+            "[UserContext:useEffect:checkAuth] /api/v1/users/me 응답 상태:",
             response.status
           ); // 로그 추가
 
           if (response.ok) {
             const data = await response.json();
             console.log(
-              '[UserContext:useEffect:checkAuth] /api/v1/users/me 성공. 데이터:',
+              "[UserContext:useEffect:checkAuth] /api/v1/users/me 성공. 데이터:",
               data
             ); // 로그 추가
 
@@ -228,82 +249,86 @@ export function UserProvider({ children }: { children: ReactNode }) {
             };
 
             console.log(
-              '[UserContext:useEffect:checkAuth] setUser(data) 호출 전. data:',
+              "[UserContext:useEffect:checkAuth] setUser(data) 호출 전. data:",
               userData
             ); // 로그 추가
             setUser(userData);
             console.log(
-              '[UserContext:useEffect:checkAuth] setUser(data) 호출 후. user 상태:',
+              "[UserContext:useEffect:checkAuth] setUser(data) 호출 후. user 상태:",
               userData
             ); // 로그 추가
 
             console.log(
-              '[UserContext:useEffect:checkAuth] localStorage 업데이트 시작'
+              "[UserContext:useEffect:checkAuth] localStorage 업데이트 시작"
             ); // 로그 추가
-            localStorage.setItem('isLoggedIn', 'true');
-            localStorage.setItem('userId', data.id.toString());
-            localStorage.setItem('nickname', data.nickname);
-            localStorage.setItem('email', data.email);
-            localStorage.setItem('userRole', data.role); // 역할 저장 확인
+            localStorage.setItem("isLoggedIn", "true");
+            localStorage.setItem("userId", data.id.toString());
+            localStorage.setItem("nickname", data.nickname);
+            localStorage.setItem("email", data.email);
+            localStorage.setItem("userRole", data.role); // 역할 저장 확인
             console.log(
-              '[UserContext:useEffect:checkAuth] localStorage 업데이트 완료'
+              "[UserContext:useEffect:checkAuth] localStorage 업데이트 완료"
             ); // 로그 추가
 
             setError(null);
 
             // 이 로직은 그대로 두자 (로그인 페이지에서 관리자 자동 리다이렉트용)
-            if (data.role === 'ROLE_ADMIN' && pathname === '/login') {
+            if (data.role === "ROLE_ADMIN" && pathname === "/login") {
               console.log(
-                '[UserContext:useEffect:checkAuth] 관리자이고 /login 경로. /admin으로 리다이렉트.'
+                "[UserContext:useEffect:checkAuth] 관리자이고 /login 경로. /admin으로 리다이렉트."
               ); // 로그 추가
-              router.push('/admin');
+              router.push("/admin");
+            }
+
+            if (data.id) {
+              fetchVerificationStats(data.id);
             }
           } else {
             console.log(
-              '[UserContext:useEffect:checkAuth] /api/v1/users/me 실패.'
+              "[UserContext:useEffect:checkAuth] /api/v1/users/me 실패."
             ); // 로그 추가
             console.log(
-              '[UserContext:useEffect:checkAuth] setUser(null) 호출 전'
+              "[UserContext:useEffect:checkAuth] setUser(null) 호출 전"
             ); // 로그 추가
             setUser(null);
             console.log(
-              '[UserContext:useEffect:checkAuth] setUser(null) 호출 후. user 상태:',
+              "[UserContext:useEffect:checkAuth] setUser(null) 호출 후. user 상태:",
               null
             ); // 로그 추가
-            localStorage.removeItem('isLoggedIn');
-            localStorage.removeItem('userRole'); // 실패 시 역할 정보도 제거
-            setError('사용자 정보를 가져오는데 실패했습니다.');
+            localStorage.removeItem("isLoggedIn");
+            localStorage.removeItem("userRole"); // 실패 시 역할 정보도 제거
+            setError("사용자 정보를 가져오는데 실패했습니다.");
           }
         } else {
           console.log(
-            '[UserContext:useEffect:checkAuth] 로그인 상태 아님 (소셜X, 로컬 isLoggedinX). setUser(null) 호출 전'
+            "[UserContext:useEffect:checkAuth] 로그인 상태 아님 (소셜X, 로컬 isLoggedinX). setUser(null) 호출 전"
           ); // 로그 추가
           setUser(null);
           console.log(
-            '[UserContext:useEffect:checkAuth] 로그인 상태 아님. setUser(null) 호출 후. user 상태:',
+            "[UserContext:useEffect:checkAuth] 로그인 상태 아님. setUser(null) 호출 후. user 상태:",
             null
           ); // 로그 추가
         }
       } catch (error) {
-        console.error('[UserContext:useEffect:checkAuth] 오류 발생:', error); // 로그 추가
+        console.error("[UserContext:useEffect:checkAuth] 오류 발생:", error); // 로그 추가
         console.log(
-          '[UserContext:useEffect:checkAuth] 오류 - setUser(null) 호출 전'
+          "[UserContext:useEffect:checkAuth] 오류 - setUser(null) 호출 전"
         ); // 로그 추가
         setUser(null);
         console.log(
-          '[UserContext:useEffect:checkAuth] 오류 - setUser(null) 호출 후. user 상태:',
+          "[UserContext:useEffect:checkAuth] 오류 - setUser(null) 호출 후. user 상태:",
           null
         ); // 로그 추가
-        localStorage.removeItem('isLoggedIn'); // 오류 시에도 로그인 상태 제거
-        localStorage.removeItem('userRole'); // 오류 시 역할 정보도 제거
-        setError('인증 과정에서 오류가 발생했습니다.');
+        localStorage.removeItem("isLoggedIn"); // 오류 시에도 로그인 상태 제거
+        localStorage.removeItem("userRole"); // 오류 시 역할 정보도 제거
+        setError("인증 과정에서 오류가 발생했습니다.");
       } finally {
         console.log(
-          '[UserContext:useEffect:checkAuth] finally 블록 시작. setLoading(false) 호출 전'
+          "[UserContext:useEffect:checkAuth] finally 블록 시작. setLoading(false) 호출 전"
         ); // 로그 추가
         setLoading(false);
         console.log(
-          '[UserContext:useEffect:checkAuth] finally 블록 - setLoading(false) 호출 후. loading 상태:',
+          "[UserContext:useEffect:checkAuth] finally 블록 - setLoading(false) 호출 후. loading 상태:",
           false
         ); // 로그 추가
       }
@@ -314,6 +339,57 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
   const mutate = async () => {
     await fetchUserInfo();
+  };
+
+  // 인증 관련 정보를 가져오는 함수 추가
+  const fetchVerificationStats = async (userId: number) => {
+    try {
+      // 1. 연속 인증일수 가져오기
+      const streakResponse = await fetch(
+        `http://localhost:8090/api/v1/verifications/streak`,
+        {
+          credentials: "include",
+        }
+      );
+
+      let streakDays = 0;
+      if (streakResponse.ok) {
+        streakDays = await streakResponse.json();
+      }
+
+      // 2. 인증 게시글만 필터링하여 가져오기 (categoryId가 1인 게시글만)
+      const verificationPostsResponse = await fetch(
+        `http://localhost:8090/api/v1/posts/user/${userId}?categoryId=1`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (verificationPostsResponse.ok) {
+        const verificationPosts = await verificationPostsResponse.json();
+
+        // 총 인증일수 = 인증 게시글 수
+        const totalVerificationDays = verificationPosts.length;
+
+        // 디톡스 시간 계산 - 모든 인증 게시글의 detoxTime 합산
+        let totalDetoxTime = 0;
+        verificationPosts.forEach((post: Post) => {
+          if (post.detoxTime) {
+            totalDetoxTime += post.detoxTime;
+          }
+        });
+
+        // stats 상태 업데이트
+        setStats({
+          detoxDays: totalVerificationDays,
+          streakDays: streakDays,
+          detoxTime: totalDetoxTime,
+          completionRate: 85, // 다시 추가
+        });
+      }
+    } catch (error) {
+      console.error("Error fetching verification stats:", error);
+    }
   };
 
   return (
@@ -329,7 +405,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
 export function useUser() {
   const context = useContext(UserContext);
   if (context === undefined) {
-    throw new Error('useUser must be used within a UserProvider');
+    throw new Error("useUser must be used within a UserProvider");
   }
   return context;
 }

--- a/fe/src/utils/profileHelpers.ts
+++ b/fe/src/utils/profileHelpers.ts
@@ -1,0 +1,18 @@
+import { User } from "@/contexts/UserContext";
+
+/**
+ * 프로필 페이지 경로를 생성합니다.
+ * 현재 로그인한 사용자(currentUser)와 접근하려는 프로필 사용자(targetUserId)가 동일하면
+ * /profile/me로 이동하고, 다른 사용자면 /profile/{targetUserId}로 이동합니다.
+ */
+export function getProfilePath(
+  currentUser: User | null,
+  targetUserId: number
+): string {
+  // 사용자가 로그인한 상태이고, 현재 사용자 ID와 대상 사용자 ID가 일치하면
+  if (currentUser && currentUser.id === targetUserId) {
+    return "/profile/me";
+  }
+  // 그렇지 않으면 ID로 프로필 접근
+  return `/profile/${targetUserId}`;
+}


### PR DESCRIPTION
---
name: 🧠 Feature
about: 새로운 기능을 추가하는 PR 템플릿입니다.
title: "[FEAT] 대상 - 추가 기능 - #이슈번호"
labels: 🧠 merge feature

---
</br>

# 🧠 Feature PR

새로운 기능을 추가하는 PR입니다. 

</br>

> ### 📝 PR 제목 규칙
> **❝ [FEAT] 대상 - 추가 기능 - #이슈번호 ❞**
</br>*( 예: ❛ [FEAT] PostService - 게시글 생성 기능 추가 - #13 ❜ )* 

✒️커밋 메시지와 동일하게 쓰시면 됩니다.

</br></br>
---

### ✏️ 여기부터 써주시면 됩니다.
* [FEAT] FE - 프로필 페이지 - '총 인증일수', '연속인증일수', '디톡스시간' 반영 
* [FEAT] FE - 프로필 페이지 - 게시글 피드에서 게시글 클릭하면 게시글 상세보기 모달창 나오게
* 그외 자잘한 문제 해결

.
</br>.

### 1️⃣관련 이슈
이슈 링크 달아주세요. 

🔗 #117 
</br></br>
.
### 2️⃣작업 내용
어떤 기능을 구현했는지 간단히 설명

✒️**FE**
* 메인페이지
    * 프로필카드에 프로필사진 반영 안되는 문제 해결
    * 프로필 조회 페이지 구조 안정화(?) -> 기존 방식은 메인화면에서 네비게이션 바&왼쪽의 프로필을 클릭해야만 `profile/me/page.tsx`로 넘어갔었고, 메인화면(Post.psx)에서 어떤 닉네임을 눌러 프로필 페이지로 넘어가려 할 때는 `profile/[id]/page.tsx`로 넘어가서 닉네임이 현재 로그인한 사용자인지 다른 사용자인지 판별하고 팔로우버튼을 띄울지 프로필 수정버튼을 띄울지 나눴었는데, 메인화면에서 프로필창 넘어가기 전에 닉네임으로 한번 판별하고, 자기 자신이면 `profile/me/page.tsx`로 무조건 보내게 하기
<br
* 프로필 페이지
    * 총 인증일 수, 연속인증일 수, 디지털디톡스 시간 be반영
    * 작성한 글 갯수가 잘못 연결되어있어서 posts.length로 수정
    * (총 인증일 수 = 인증게시판에 쓴 게시글 수) 여야하는데 (총 인증일 수 = 총 게시글 수)로 반영되는 문제해결
    * 게시글 피드의 게시글 클릭하면 commentModal페이지 나오도록 하기
    * 게시글 피드의 게시글에 첨부된 사진도 반영되게 하기
    * 프로필사진에 세로로 긴 사진이 등록되면 타원형이 되는 문제 해결(원형으로 고정)



✒️**BE**
X

</br></br>

.
### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [x] 로컬에서 테스트 완료 🧪🫧

</br></br>



