### PR TITLE
[fix] FE - 프로필페이지 - 댓글 피드 반영, 연속인증일수=총 게시글 수로 표시되는 오류, 목표달성률 

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/post/comment/controller/ApiV1CommentController.java
+++ b/be/src/main/java/com/dd/blog/domain/post/comment/controller/ApiV1CommentController.java
@@ -40,6 +40,21 @@ public class ApiV1CommentController {
         return ResponseEntity.ok(comments);
     }
 
+    // READ
+    // 특정 사용자가 작성한 모든 댓글 조회
+    @Operation(
+            summary = "사용자 댓글 목록 조회",
+            description = "사용자 ID를 통해 해당 사용자가 작성한 모든 댓글을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "404", description = "해당 사용자 없음")
+            }
+    )
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<CommentResponseDto>> getUserComments(@PathVariable Long userId){
+        List<CommentResponseDto> comments = commentService.getCommentsByUserId(userId);
+        return ResponseEntity.ok(comments);
+    }
 
     // CREATE
     // 댓글, 대댓글

--- a/be/src/main/java/com/dd/blog/domain/post/comment/repository/CommentRepository.java
+++ b/be/src/main/java/com/dd/blog/domain/post/comment/repository/CommentRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment,Long> {
     List<Comment> findByPostId(Long post_id);
 //    List<Comment> findByParentId(Long parent_id);
+    List<Comment> findByUserId(Long userId);
 }

--- a/be/src/main/java/com/dd/blog/domain/post/comment/service/CommentService.java
+++ b/be/src/main/java/com/dd/blog/domain/post/comment/service/CommentService.java
@@ -104,4 +104,20 @@ public class CommentService {
         }
         commentRepository.delete(comment);
     };
+
+    // 특정 사용자의 모든 댓글 조회
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByUserId(Long userId) {
+        // 사용자 존재 여부 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 댓글 리포지토리에서 userId로 댓글 조회
+        List<Comment> comments = commentRepository.findByUserId(userId);
+
+        // DTO로 변환하여 반환
+        return comments.stream()
+                .map(CommentResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
 }

--- a/be/src/main/java/com/dd/blog/domain/user/user/dto/UpdateProfileRequestDto.java
+++ b/be/src/main/java/com/dd/blog/domain/user/user/dto/UpdateProfileRequestDto.java
@@ -17,7 +17,7 @@ public class UpdateProfileRequestDto {
     private String nickname;
     private String email;
     private String statusMessage;
-    private String detoxGoal;
+    private Integer detoxGoal;
     private LocalDate birthDate;
     private String profileImageUrl;
 } 

--- a/be/src/main/java/com/dd/blog/domain/user/user/dto/UserResponseDto.java
+++ b/be/src/main/java/com/dd/blog/domain/user/user/dto/UserResponseDto.java
@@ -24,7 +24,7 @@ public class UserResponseDto {
     private LocalDateTime createdAt;
     private boolean isSocialUser;
     private String statusMessage;
-    private String detoxGoal;
+    private Integer detoxGoal;
     private LocalDate birthDate;
     private String profileImageUrl;
 

--- a/be/src/main/java/com/dd/blog/domain/user/user/entity/User.java
+++ b/be/src/main/java/com/dd/blog/domain/user/user/entity/User.java
@@ -69,8 +69,8 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "status_message", length = 200)
     private String statusMessage;
 
-    @Column(name = "detox_goal", length = 500)
-    private String detoxGoal;
+    @Column(name = "detox_goal")
+    private Integer detoxGoal;
 
     @Column(name = "birth_date")
     private LocalDate birthDate;
@@ -130,7 +130,7 @@ public class User extends BaseEntity implements UserDetails {
         this.socialId = socialId;
     }
 
-    public void updateProfile(String nickname, String email, String statusMessage, String detoxGoal, LocalDate birthDate, String profileImageUrl) {
+    public void updateProfile(String nickname, String email, String statusMessage, Integer detoxGoal, LocalDate birthDate, String profileImageUrl) {
         this.nickname = nickname;
         this.email = email;
         this.statusMessage = statusMessage;

--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -724,14 +724,17 @@ export default function Home() {
               ) : user ? (
                 <div className="flex flex-col items-center">
                   <Link href={`/profile/me`}>
-                    <div className="rounded-full bg-pink-100 border-4 border-pink-200 p-4 mb-3 cursor-pointer">
+                    <div
+                      className="rounded-full bg-pink-100 border-4 border-pink-200 p-0 mb-3 cursor-pointer flex items-center justify-center overflow-hidden"
+                      style={{ width: "72px", height: "72px" }}
+                    >
                       {user.profileImage ? (
                         <Image
                           src={user.profileImage}
                           alt={`${user.nickname}의 프로필`}
-                          width={40}
-                          height={40}
-                          className="rounded-full w-10 h-10 object-cover"
+                          width={72}
+                          height={72}
+                          className="w-full h-full object-cover rounded-full"
                           unoptimized={true}
                         />
                       ) : (

--- a/fe/src/app/profile/[id]/page.tsx
+++ b/fe/src/app/profile/[id]/page.tsx
@@ -101,11 +101,18 @@ export default function OtherUserProfile() {
           const userData = {
             ...data,
             profileImage: data.profileImageUrl,
+            detoxGoal:
+              data.detoxGoal !== undefined && data.detoxGoal !== null
+                ? parseInt(data.detoxGoal.toString())
+                : 0,
           };
+          console.log("변환된 userData:", userData);
           setUserInfo(userData);
           fetchFollowStats(data.id);
           fetchUserPosts(data.id);
-          fetchVerificationStats(data.id);
+          setTimeout(() => {
+            fetchVerificationStats(data.id);
+          }, 100);
           fetchUserComments(data.id);
 
           // 팔로우 상태 확인 (나를 기준으로 해당 사용자를 팔로우하고 있는지)
@@ -495,12 +502,21 @@ export default function OtherUserProfile() {
           }
         });
 
+        // 목표 달성률 계산 - detoxGoal이 설정되어 있고 0보다 큰 경우에만 계산
+        let completionRate = 0;
+        if (userInfo.detoxGoal && userInfo.detoxGoal > 0) {
+          completionRate = Math.min(
+            100,
+            Math.round((totalDetoxTime / userInfo.detoxGoal) * 100)
+          );
+        }
+
         // stats 상태 업데이트
         setStats({
           detoxDays: totalVerificationDays,
           streakDays: streakDays,
           detoxTime: totalDetoxTime,
-          completionRate: 0,
+          completionRate: completionRate,
         });
       }
     } catch (error) {
@@ -850,7 +866,13 @@ export default function OtherUserProfile() {
                     <div
                       className="h-full rounded-full transition-all duration-300"
                       style={{
-                        width: `${(stats.detoxTime / 48) * 100}%`,
+                        width:
+                          userInfo.detoxGoal && userInfo.detoxGoal > 0
+                            ? `${Math.min(
+                                100,
+                                (stats.detoxTime / userInfo.detoxGoal) * 100
+                              )}%`
+                            : "0%",
                         backgroundColor: CUSTOM_PINK,
                       }}
                     ></div>

--- a/fe/src/app/profile/[id]/page.tsx
+++ b/fe/src/app/profile/[id]/page.tsx
@@ -457,7 +457,7 @@ export default function OtherUserProfile() {
     try {
       // 1. 연속 인증일수 가져오기
       const streakResponse = await fetch(
-        `http://localhost:8090/api/v1/verifications/streak/${userId}`,
+        `http://localhost:8090/api/v1/verifications/streak`,
         {
           credentials: "include",
         }
@@ -828,12 +828,6 @@ export default function OtherUserProfile() {
                   <span className="text-gray-600">총 인증일수</span>
                   <span className="font-medium" style={{ color: CUSTOM_PINK }}>
                     {stats.detoxDays}일
-                  </span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-600">연속 인증일수</span>
-                  <span className="font-medium" style={{ color: CUSTOM_PINK }}>
-                    {stats.streakDays}일
                   </span>
                 </div>
                 <div className="flex items-center justify-between text-sm">

--- a/fe/src/app/profile/me/edit/page.tsx
+++ b/fe/src/app/profile/me/edit/page.tsx
@@ -1,67 +1,67 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import DatePicker from 'react-datepicker';
-import 'react-datepicker/dist/react-datepicker.css';
-import { ko } from 'date-fns/locale';
-import { toast } from 'react-hot-toast';
-import { UserInfo } from '@/types/user';
+import Image from "next/image";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import { ko } from "date-fns/locale";
+import { toast } from "react-hot-toast";
+import { UserInfo } from "@/types/user";
 
-const CUSTOM_PINK = '#F742CD';
+const CUSTOM_PINK = "#F742CD";
 
 export default function EditProfile() {
   const router = useRouter();
   const [userInfo, setUserInfo] = useState<UserInfo>({
     id: null,
-    nickname: '',
-    email: '',
-    statusMessage: '',
-    detoxGoal: '',
+    nickname: "",
+    email: "",
+    statusMessage: "",
+    detoxGoal: 0,
     birthDate: null,
     profileImage: null,
   });
-  const [profileImage, setProfileImage] = useState('/placeholder-avatar.png');
+  const [profileImage, setProfileImage] = useState("/placeholder-avatar.png");
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
   const [passwordForm, setPasswordForm] = useState({
-    newPassword: '',
-    confirmPassword: '',
+    newPassword: "",
+    confirmPassword: "",
   });
-  const [passwordError, setPasswordError] = useState('');
+  const [passwordError, setPasswordError] = useState("");
 
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
-        const response = await fetch('http://localhost:8090/api/v1/users/me', {
-          credentials: 'include',
+        const response = await fetch("http://localhost:8090/api/v1/users/me", {
+          credentials: "include",
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
         });
 
         if (response.ok) {
           const data = await response.json();
-          console.log('Loaded user data:', data);
+          console.log("Loaded user data:", data);
           setUserInfo({
             ...data,
             birthDate: data.birthDate ? new Date(data.birthDate) : null,
             profileImage: data.profileImageUrl,
-            statusMessage: data.statusMessage || '',
-            detoxGoal: data.detoxGoal || '',
+            statusMessage: data.statusMessage || "",
+            detoxGoal: data.detoxGoal || 0,
           });
           if (data.profileImageUrl) {
             setProfileImage(data.profileImageUrl);
           }
         } else {
-          toast.error('프로필 정보를 불러오는데 실패했습니다.');
-          router.push('/login');
+          toast.error("프로필 정보를 불러오는데 실패했습니다.");
+          router.push("/login");
         }
       } catch (error) {
-        console.error('Error fetching user info:', error);
-        toast.error('서버 연결에 실패했습니다.');
+        console.error("Error fetching user info:", error);
+        toast.error("서버 연결에 실패했습니다.");
       }
     };
 
@@ -70,46 +70,46 @@ export default function EditProfile() {
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    console.log('Selected file:', file);
+    console.log("Selected file:", file);
 
     if (file) {
       // 파일 크기 제한 (10MB)
       if (file.size > 10 * 1024 * 1024) {
-        toast.error('파일 크기는 10MB를 초과할 수 없습니다.');
+        toast.error("파일 크기는 10MB를 초과할 수 없습니다.");
         return;
       }
 
       // 이미지 파일 타입 체크
-      if (!file.type.startsWith('image/')) {
-        toast.error('이미지 파일만 업로드 가능합니다.');
+      if (!file.type.startsWith("image/")) {
+        toast.error("이미지 파일만 업로드 가능합니다.");
         return;
       }
 
       try {
-        toast.loading('이미지 업로드 중...');
+        toast.loading("이미지 업로드 중...");
         const formData = new FormData();
-        formData.append('file', file);
+        formData.append("file", file);
 
         console.log(
-          'Uploading file:',
+          "Uploading file:",
           file.name,
-          'Size:',
+          "Size:",
           file.size,
-          'Type:',
+          "Type:",
           file.type
         );
 
-        const response = await fetch('http://localhost:8090/api/v1/s3/upload', {
-          method: 'POST',
-          credentials: 'include',
+        const response = await fetch("http://localhost:8090/api/v1/s3/upload", {
+          method: "POST",
+          credentials: "include",
           body: formData,
         });
 
-        console.log('Upload response status:', response.status);
+        console.log("Upload response status:", response.status);
 
         if (response.ok) {
           const imageUrl = await response.text();
-          console.log('Upload response data:', imageUrl);
+          console.log("Upload response data:", imageUrl);
 
           setProfileImage(imageUrl);
           setUserInfo((prev) => ({
@@ -117,20 +117,20 @@ export default function EditProfile() {
             profileImage: imageUrl,
           }));
           toast.dismiss();
-          toast.success('프로필 이미지가 업로드되었습니다.');
+          toast.success("프로필 이미지가 업로드되었습니다.");
         } else {
           const errorData = await response.text();
-          console.error('Upload failed:', errorData);
+          console.error("Upload failed:", errorData);
           toast.dismiss();
           toast.error(
-            '이미지 업로드에 실패했습니다: ' +
+            "이미지 업로드에 실패했습니다: " +
               (errorData || response.statusText)
           );
         }
       } catch (error) {
-        console.error('Error uploading image:', error);
+        console.error("Error uploading image:", error);
         toast.dismiss();
-        toast.error('이미지 업로드 중 오류가 발생했습니다.');
+        toast.error("이미지 업로드 중 오류가 발생했습니다.");
       }
     }
   };
@@ -139,10 +139,11 @@ export default function EditProfile() {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
-    console.log('Field changed:', name, value);
+    console.log("Field changed:", name, value);
+
     setUserInfo((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: name === "detoxGoal" ? parseInt(value) || 0 : value,
     }));
   };
 
@@ -151,7 +152,7 @@ export default function EditProfile() {
     setIsLoading(true);
 
     try {
-      console.log('Current userInfo state:', userInfo);
+      console.log("Current userInfo state:", userInfo);
 
       const updateData = {
         nickname: userInfo.nickname,
@@ -159,114 +160,114 @@ export default function EditProfile() {
         statusMessage: userInfo.statusMessage,
         detoxGoal: userInfo.detoxGoal,
         birthDate: userInfo.birthDate
-          ? userInfo.birthDate.toISOString().split('T')[0]
+          ? userInfo.birthDate.toISOString().split("T")[0]
           : null,
         profileImageUrl: userInfo.profileImage,
       };
 
-      console.log('Sending update request with data:', updateData);
-      console.log('User ID:', userInfo.id);
+      console.log("Sending update request with data:", updateData);
+      console.log("User ID:", userInfo.id);
 
       // FormData 객체 생성
       const formData = new FormData();
 
       // profileData를 JSON 문자열로 변환하여 추가
       formData.append(
-        'profileData',
+        "profileData",
         new Blob([JSON.stringify(updateData)], {
-          type: 'application/json',
+          type: "application/json",
         })
       );
 
       // 프로필 이미지가 변경된 경우에만 이미지 파일 추가
       if (
         userInfo.profileImage &&
-        userInfo.profileImage !== '/placeholder-avatar.png' &&
-        userInfo.profileImage.startsWith('http')
+        userInfo.profileImage !== "/placeholder-avatar.png" &&
+        userInfo.profileImage.startsWith("http")
       ) {
         // 이미지가 URL인 경우는 FormData에 포함하지 않고 profileImageUrl로 전송
-        console.log('프로필 이미지 URL이 전송됩니다:', userInfo.profileImage);
+        console.log("프로필 이미지 URL이 전송됩니다:", userInfo.profileImage);
       }
 
       const response = await fetch(
         `http://localhost:8090/api/v1/users/${userInfo.id}`,
         {
-          method: 'PUT',
-          credentials: 'include',
+          method: "PUT",
+          credentials: "include",
           body: formData, // Content-Type은 자동으로 multipart/form-data로 설정됨
         }
       );
 
-      console.log('Response status:', response.status);
+      console.log("Response status:", response.status);
       const responseData = await response.json();
-      console.log('Response data:', responseData);
+      console.log("Response data:", responseData);
 
       if (response.ok) {
-        toast.success('프로필이 성공적으로 업데이트되었습니다.');
+        toast.success("프로필이 성공적으로 업데이트되었습니다.");
         router.refresh();
-        router.push('/profile/me');
+        router.push("/profile/me");
       } else {
-        toast.error(responseData.message || '프로필 업데이트에 실패했습니다.');
+        toast.error(responseData.message || "프로필 업데이트에 실패했습니다.");
       }
     } catch (error) {
-      console.error('Error updating profile:', error);
-      toast.error('서버 연결에 실패했습니다.');
+      console.error("Error updating profile:", error);
+      toast.error("서버 연결에 실패했습니다.");
     } finally {
       setIsLoading(false);
     }
   };
 
   const handlePasswordChange = async () => {
-    console.log('비밀번호 변경 시도:', passwordForm);
+    console.log("비밀번호 변경 시도:", passwordForm);
 
     if (passwordForm.newPassword !== passwordForm.confirmPassword) {
-      setPasswordError('비밀번호가 일치하지 않습니다.');
+      setPasswordError("비밀번호가 일치하지 않습니다.");
       return;
     }
 
     if (passwordForm.newPassword.length < 6) {
-      setPasswordError('비밀번호는 6자 이상이어야 합니다.');
+      setPasswordError("비밀번호는 6자 이상이어야 합니다.");
       return;
     }
 
     try {
-      console.log('API 호출 시도:', userInfo.id);
+      console.log("API 호출 시도:", userInfo.id);
       const response = await fetch(
         `http://localhost:8090/api/v1/users/${userInfo.id}/password`,
         {
-          method: 'PUT',
-          credentials: 'include',
+          method: "PUT",
+          credentials: "include",
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
           body: JSON.stringify({ newPassword: passwordForm.newPassword }),
         }
       );
 
-      console.log('API 응답:', response.status);
+      console.log("API 응답:", response.status);
       const data = await response.json();
 
       if (response.ok) {
-        toast.success(data.message || '비밀번호가 성공적으로 변경되었습니다.');
+        toast.success(data.message || "비밀번호가 성공적으로 변경되었습니다.");
         setIsPasswordModalOpen(false);
-        setPasswordForm({ newPassword: '', confirmPassword: '' });
-        setPasswordError('');
+        setPasswordForm({ newPassword: "", confirmPassword: "" });
+        setPasswordError("");
       } else {
-        console.error('비밀번호 변경 실패:', data);
-        setPasswordError(data.message || '비밀번호 변경에 실패했습니다.');
-        toast.error(data.message || '비밀번호 변경에 실패했습니다.');
+        console.error("비밀번호 변경 실패:", data);
+        setPasswordError(data.message || "비밀번호 변경에 실패했습니다.");
+        toast.error(data.message || "비밀번호 변경에 실패했습니다.");
       }
     } catch (error) {
-      console.error('Error changing password:', error);
-      setPasswordError('서버 연결에 실패했습니다.');
-      toast.error('서버 연결에 실패했습니다.');
+      console.error("Error changing password:", error);
+      setPasswordError("서버 연결에 실패했습니다.");
+      toast.error("서버 연결에 실패했습니다.");
     }
   };
 
   const handleDeleteAccount = async () => {
     if (
       !window.confirm(
-        '정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'
+        "정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
       )
     ) {
       return;
@@ -277,10 +278,10 @@ export default function EditProfile() {
       const deleteResponse = await fetch(
         `http://localhost:8090/api/v1/users/${userInfo.id}`,
         {
-          method: 'DELETE',
-          credentials: 'include',
+          method: "DELETE",
+          credentials: "include",
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
         }
       );
@@ -288,29 +289,29 @@ export default function EditProfile() {
       if (deleteResponse.ok) {
         // 로그아웃 요청
         const logoutResponse = await fetch(
-          'http://localhost:8090/api/v1/users/logout',
+          "http://localhost:8090/api/v1/users/logout",
           {
-            method: 'POST',
-            credentials: 'include',
+            method: "POST",
+            credentials: "include",
             headers: {
-              'Content-Type': 'application/json',
+              "Content-Type": "application/json",
             },
           }
         );
 
         if (logoutResponse.ok) {
-          toast.success('계정이 성공적으로 삭제되었습니다.');
-          router.push('/');
+          toast.success("계정이 성공적으로 삭제되었습니다.");
+          router.push("/");
         } else {
-          console.error('로그아웃 실패');
-          router.push('/');
+          console.error("로그아웃 실패");
+          router.push("/");
         }
       } else {
-        toast.error('계정 삭제에 실패했습니다.');
+        toast.error("계정 삭제에 실패했습니다.");
       }
     } catch (error) {
-      console.error('Error deleting account:', error);
-      toast.error('서버 연결에 실패했습니다.');
+      console.error("Error deleting account:", error);
+      toast.error("서버 연결에 실패했습니다.");
     }
   };
 
@@ -371,7 +372,7 @@ export default function EditProfile() {
                 className="hidden"
                 onChange={handleImageChange}
                 onClick={(e) => {
-                  (e.target as HTMLInputElement).value = '';
+                  (e.target as HTMLInputElement).value = "";
                 }}
               />
             </div>
@@ -409,14 +410,20 @@ export default function EditProfile() {
               <label className="block text-xs text-gray-500 mb-1">
                 도파민 디톡스 목표
               </label>
-              <textarea
-                name="detoxGoal"
-                value={userInfo.detoxGoal}
-                onChange={handleChange}
-                rows={2}
-                className="w-full px-0 py-1 bg-transparent border-0 focus:ring-0 resize-none text-sm"
-                placeholder="도파민 디톡스 목표를 입력하세요"
-              />
+              <div className="flex items-center">
+                <input
+                  type="number"
+                  name="detoxGoal"
+                  value={userInfo.detoxGoal || 0}
+                  onChange={handleChange}
+                  min="0"
+                  className="w-24 px-0 py-1 bg-transparent border-0 focus:ring-0 text-sm"
+                  placeholder="0"
+                  inputMode="numeric"
+                  onFocus={(e) => e.target.select()}
+                />
+                <span className="ml-2 text-sm">시간</span>
+              </div>
             </div>
 
             <div className="pb-6 border-b border-gray-100">
@@ -482,10 +489,10 @@ export default function EditProfile() {
                   onClick={() => {
                     setIsPasswordModalOpen(false);
                     setPasswordForm({
-                      newPassword: '',
-                      confirmPassword: '',
+                      newPassword: "",
+                      confirmPassword: "",
                     });
-                    setPasswordError('');
+                    setPasswordError("");
                   }}
                   className="text-gray-500 text-sm hover:text-gray-700 transition-colors"
                 >

--- a/fe/src/app/profile/me/page.tsx
+++ b/fe/src/app/profile/me/page.tsx
@@ -169,7 +169,7 @@ export default function MyProfile() {
     try {
       // 1. 연속 인증일수 가져오기
       const streakResponse = await fetch(
-        `http://localhost:8090/api/v1/verifications/streak/${userId}`,
+        `http://localhost:8090/api/v1/verifications/streak`,
         {
           credentials: "include",
         }

--- a/fe/src/app/profile/me/page.tsx
+++ b/fe/src/app/profile/me/page.tsx
@@ -77,6 +77,10 @@ export default function MyProfile() {
   const [selectedPost, setSelectedPost] = useState<Post | null>(null);
   const [showCommentModal, setShowCommentModal] = useState(false);
 
+  // 새로 추가한 상태
+  const [userComments, setUserComments] = useState<any[]>([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
@@ -100,6 +104,7 @@ export default function MyProfile() {
             fetchFollowStats(data.id);
             fetchUserPosts(data.id);
             fetchVerificationStats(data.id);
+            fetchUserComments(data.id);
           }
         } else {
           console.error("프로필 정보를 불러오는데 실패했습니다.");
@@ -175,23 +180,28 @@ export default function MyProfile() {
         streakDays = await streakResponse.json();
       }
 
-      // 2. 인증 게시글만 필터링하여 가져오기 (categoryId가 1인 게시글만)
-      const verificationPostsResponse = await fetch(
-        `http://localhost:8090/api/v1/posts/user/${userId}?categoryId=3`,
+      // 2. 인증 카테고리(categoryId=1)의 모든 게시물 가져오기
+      const categoryPostsResponse = await fetch(
+        `http://localhost:8090/api/v1/posts/category/1`,
         {
           credentials: "include",
         }
       );
 
-      if (verificationPostsResponse.ok) {
-        const verificationPosts = await verificationPostsResponse.json();
+      if (categoryPostsResponse.ok) {
+        const allCategoryPosts = await categoryPostsResponse.json();
 
-        // 총 인증일수 = 인증 게시글 수
-        const totalVerificationDays = verificationPosts.length;
+        // 3. 현재 사용자가 작성한 인증 게시물만 필터링
+        const userVerificationPosts = allCategoryPosts.filter(
+          (post: Post) => post.userId === userId
+        );
 
-        // 디톡스 시간 계산 - 모든 인증 게시글의 detoxTime 합산
+        // 총 인증일수 = 해당 사용자의 인증 게시글 수
+        const totalVerificationDays = userVerificationPosts.length;
+
+        // 디톡스 시간 계산 - 해당 사용자의 인증 게시글의 detoxTime 합산
         let totalDetoxTime = 0;
-        verificationPosts.forEach((post: Post) => {
+        userVerificationPosts.forEach((post: Post) => {
           if (post.detoxTime) {
             totalDetoxTime += post.detoxTime;
           }
@@ -202,12 +212,84 @@ export default function MyProfile() {
           detoxDays: totalVerificationDays,
           streakDays: streakDays,
           detoxTime: totalDetoxTime,
-          completionRate: 85,
+          completionRate: 0,
           badges: 12,
         });
       }
     } catch (error) {
       console.error("Error fetching verification stats:", error);
+    }
+  };
+
+  const fetchUserComments = async (userId: number) => {
+    try {
+      setCommentsLoading(true);
+      // 올바른 API 엔드포인트로 사용자 댓글 가져오기
+      const response = await fetch(
+        `http://localhost:8090/api/v1/comments/user/${userId}`,
+        {
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        const comments = await response.json();
+        console.log("사용자 댓글 데이터:", comments);
+
+        if (!Array.isArray(comments)) {
+          console.error("댓글 데이터가 배열이 아닙니다:", comments);
+          setUserComments([]);
+          return;
+        }
+
+        // 댓글 데이터 정제 (snake_case -> camelCase)
+        const processedComments = comments.map((comment: any) => ({
+          ...comment,
+          userId: comment.userId || comment.user_id,
+          postId: comment.postId || comment.post_id,
+          parentId: comment.parentId || comment.parent_id,
+          createdAt: comment.createdAt || comment.created_at,
+          updatedAt: comment.updatedAt || comment.updated_at,
+        }));
+
+        // 필요한 게시글 정보 가져오기
+        const commentsWithPostInfo = await Promise.all(
+          processedComments.map(async (comment: any) => {
+            if (!comment.postId) {
+              return comment;
+            }
+
+            try {
+              const postResponse = await fetch(
+                `http://localhost:8090/api/v1/posts/${comment.postId}`,
+                {
+                  credentials: "include",
+                }
+              );
+
+              if (postResponse.ok) {
+                const post = await postResponse.json();
+                return { ...comment, post };
+              }
+              return comment;
+            } catch (error) {
+              console.error(
+                `댓글 ID ${comment.id}의 게시글 정보 로드 중 오류:`,
+                error
+              );
+              return comment;
+            }
+          })
+        );
+
+        setUserComments(commentsWithPostInfo);
+      } else {
+        console.error("댓글 조회 API 오류:", response.status);
+      }
+    } catch (error) {
+      console.error("사용자 댓글 로드 중 오류:", error);
+    } finally {
+      setCommentsLoading(false);
     }
   };
 
@@ -324,6 +406,14 @@ export default function MyProfile() {
           : post
       )
     );
+  };
+
+  // 댓글 클릭시 해당 게시글 모달 표시 함수
+  const handleCommentClick = (comment: any) => {
+    if (comment.post) {
+      setSelectedPost(comment.post);
+      setShowCommentModal(true);
+    }
   };
 
   if (isLoading) {
@@ -557,9 +647,70 @@ export default function MyProfile() {
 
         {selectedTab === "comments" && (
           <div className="space-y-4">
-            <p className="text-gray-500 text-center py-8">
-              아직 작성한 댓글이 없습니다.
-            </p>
+            {commentsLoading ? (
+              <div className="flex justify-center py-10">
+                <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-pink-500"></div>
+              </div>
+            ) : userComments.length > 0 ? (
+              userComments.map((comment) => (
+                <div
+                  key={comment.id}
+                  className="border-b pb-4 cursor-pointer hover:bg-gray-50 p-3 rounded-lg transition"
+                  onClick={() => handleCommentClick(comment)}
+                >
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0">
+                      <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
+                        {userInfo.profileImage ? (
+                          <Image
+                            src={userInfo.profileImage}
+                            alt="프로필 이미지"
+                            width={32}
+                            height={32}
+                            className="w-full h-full object-cover"
+                            unoptimized={true}
+                          />
+                        ) : (
+                          <svg
+                            className="w-4 h-4 text-gray-500"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="font-medium text-sm">
+                            @{userInfo.nickname}
+                          </p>
+                          <span className="text-xs text-gray-400">
+                            {getTimeAgo(comment.createdAt)}
+                          </span>
+                        </div>
+                      </div>
+                      <p className="text-gray-800 mt-1">{comment.content}</p>
+                      {comment.post && (
+                        <div className="mt-2 text-xs text-gray-500">
+                          <span>게시글: {comment.post.title}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <p className="text-gray-500 text-center py-8">
+                아직 작성한 댓글이 없습니다.
+              </p>
+            )}
           </div>
         )}
 

--- a/fe/src/types/user.ts
+++ b/fe/src/types/user.ts
@@ -6,7 +6,7 @@ export interface UserInfo {
   totalPoint?: number;
   createdAt?: string | null;
   statusMessage?: string;
-  detoxGoal?: string;
+  detoxGoal?: number;
   birthDate?: Date | null;
   profileImage?: string | null;
-} 
+}


### PR DESCRIPTION
---
name: 🧠 Feature
about: 새로운 기능을 추가하는 PR 템플릿입니다.
title: "[FEAT] 대상 - 추가 기능 - #이슈번호"
labels: 🧠 merge feature

---
</br>

# 🧠 Feature PR

새로운 기능을 추가하는 PR입니다. 

</br>

> ### 📝 PR 제목 규칙
> **❝ [FEAT] 대상 - 추가 기능 - #이슈번호 ❞**
</br>*( 예: ❛ [FEAT] PostService - 게시글 생성 기능 추가 - #13 ❜ )* 

✒️커밋 메시지와 동일하게 쓰시면 됩니다.

</br></br>
---

### ✏️ 여기부터 써주시면 됩니다.
* [FEAT] FE - 프로필 페이지 - '총 인증일수', '연속인증일수', '디톡스시간' 반영 
.
</br>.

### 1️⃣관련 이슈
이슈 링크 달아주세요. 

🔗 #151 
</br></br>
.
### 2️⃣작업 내용
어떤 기능을 구현했는지 간단히 설명

✒️**FE**
* 프로필페이지  
    * 작성한 모든 댓글목록 피드에 띄우기
    * 연속인증일 수 = 인증게시판에 쓴 글 갯수 여야 하는데 현재 작성한 모든 게시글 수가 반영되는 문제 해결 
    * 목표달성률 - String detoxGoal을 Int detoxGoal로 바꿔서 입력을 받은 다음, null상태라면 default로 0%를, 사용자가 어느 숫자든(nn시간) 입력을 하면 누적된 디톡스시간과 비교하여 달성률 반영
    * 다른 사용자 프로필 조회 페이지의 디톡스정보 탭에서 '연속인증일 수' 제거
    (현재 엔드포인트는 /streak으로 끝나서 무조건 현재 로그인한 사용자의 연속인증일 수를 받아오기 때문에 다른 사람의 연속인증일수
    까지 내 정보로 표기되는 문제가 있다. 엔드포인트를 /streak/{userId}로 바꾼다면 그에맞게 다시 여기저기 바꿔야 하기 때문에 수정 
    한다면 나중에 하는걸로 하고 일단은 지웠다. )


✒️**BE**
* User의 detoxGoal을 Integer값으로 변경.(int는 null값을 허용하지 않기 때문에 null값이 허용되는 Integer로 변경)
    * DB수정 완료, swagger테스트 완료
* 특정 사용자가 작성한 댓글 리스트 반환하는 코드 추가(CommentRepository, CommentService, ApiV1CommentController)


</br></br>

.
### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [x] 로컬에서 테스트 완료 🧪🫧

</br></br>



