### PR TITLE
[FEAT] 계정 정지 시 로그인 불가 기능 추가 #159

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/admin/controller/AdminDashboardController.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/controller/AdminDashboardController.java
@@ -20,17 +20,19 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "AdminDashboard API", description = "관리자용 메인 페이지용 주요 통계 API")
 public class AdminDashboardController {
 
-    private final AdminDashboardService adminDashboardService;
+        private final AdminDashboardService adminDashboardService;
 
 
-    @Operation(summary = "관리자용 대시보드 통계 조회", description = "대시보드에 표시될 주요 통계 정보(총 회원 수, 대기 중인 인증 수 등)를 조회")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "통계 조회 성공"),
+        @Operation(summary = "관리자용 대시보드 통계 조회", description = "대시보드에 표시될 주요 통계 정보(총 회원 수, 대기 중인 인증 수 등)를 조회")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "204", description = "통계 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자 (관리자 아님)")
     })
     @GetMapping("/stats")
     public ResponseEntity<AdminDashboardStatsDto> getDashboardStats() {
+        System.out.println(">>> HIT /api/admin/dashboard/stats Controller Method!");
+
         AdminDashboardStatsDto statsDto = adminDashboardService.getDashboardStats();
         return ResponseEntity.ok(statsDto);
     }

--- a/be/src/main/java/com/dd/blog/domain/admin/dto/AdminDashboardStatsDto.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/dto/AdminDashboardStatsDto.java
@@ -17,13 +17,11 @@ public class AdminDashboardStatsDto {
     private long reportsProcessedToday;
 
     @Builder
-    public AdminDashboardStatsDto(long totalUsers, long pendingVerifications, long verificationsProcessedToday,
-                                  long usersJoinedToday,
-                                  long pendingReports, long reportsProcessedToday) {
+    public AdminDashboardStatsDto(long totalUsers, long usersJoinedToday, long pendingVerifications, long verificationsProcessedToday, long pendingReports, long reportsProcessedToday) {
         this.totalUsers = totalUsers;
+        this.usersJoinedToday = usersJoinedToday;
         this.pendingVerifications = pendingVerifications;
         this.verificationsProcessedToday = verificationsProcessedToday;
-        this.usersJoinedToday = usersJoinedToday;
         this.pendingReports = pendingReports;
         this.reportsProcessedToday = reportsProcessedToday;
     }

--- a/be/src/main/java/com/dd/blog/domain/admin/service/AdminDashboardService.java
+++ b/be/src/main/java/com/dd/blog/domain/admin/service/AdminDashboardService.java
@@ -21,7 +21,6 @@ import java.util.List;
 public class AdminDashboardService {
 
     private final UserRepository userRepository;
-    private final PostRepository postRepository;
     private final VerificationRepository verificationRepository;
     private final ReportRepository reportRepository;
 
@@ -33,7 +32,14 @@ public class AdminDashboardService {
 
         // 각 통계 계산
         long totalUsers = userRepository.count();
+
+
+        System.out.println(">>> [AdminDashboardService] Calling verificationRepository.countByStatus(PENDING)...");
         long pendingVerifications = verificationRepository.countByStatus(VerificationStatus.PENDING);
+        System.out.println(">>> [AdminDashboardService] Result from countByStatus: " + pendingVerifications);
+
+
+
         long verificationsProcessedToday = verificationRepository.countByStatusInAndUpdatedAtBetween(
                 List.of(VerificationStatus.APPROVED, VerificationStatus.REJECTED), // 처리된 상태 목록
                 startOfDay,
@@ -52,9 +58,9 @@ public class AdminDashboardService {
 
         return AdminDashboardStatsDto.builder()
                 .totalUsers(totalUsers)
+                .usersJoinedToday(usersJoinedToday)
                 .pendingVerifications(pendingVerifications)
                 .verificationsProcessedToday(verificationsProcessedToday)
-                .usersJoinedToday(usersJoinedToday)
                 .pendingReports(pendingReports)
                 .reportsProcessedToday(reportsProcessedToday)
                 .build();

--- a/be/src/main/java/com/dd/blog/domain/user/user/service/UserService.java
+++ b/be/src/main/java/com/dd/blog/domain/user/user/service/UserService.java
@@ -132,6 +132,10 @@ public class UserService {
             throw new ApiException(ErrorCode.INVALID_PASSWORD);
         }
 
+        if (user.getStatus() == UserStatus.SUSPENDED) {
+            throw new ApiException(ErrorCode.ACCOUNT_SUSPENDED);
+        }
+
         // 리프레시 토큰 생성
         String refreshToken = authTokenService.genRefreshToken(user);
 

--- a/be/src/main/java/com/dd/blog/global/exception/ErrorCode.java
+++ b/be/src/main/java/com/dd/blog/global/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
 
     // 403 FORBIDDEN
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 관리자에게 문의하세요."), // <--- 여기 추가!
+
 
     // 404 NOT_FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),

--- a/be/src/main/java/com/dd/blog/global/security/CustomOAuth2UserService.java
+++ b/be/src/main/java/com/dd/blog/global/security/CustomOAuth2UserService.java
@@ -51,7 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         if (user.getStatus() == UserStatus.SUSPENDED) {
 
-            throw new ApiException(ErrorCode.ACCOUNT_SUSPENDED, "정지된 계정입니다. 관리자에게 문의하세요.");
+            throw new ApiException(ErrorCode.ACCOUNT_SUSPENDED);
         }
 
         return new SecurityUser(

--- a/be/src/main/java/com/dd/blog/global/security/CustomOAuth2UserService.java
+++ b/be/src/main/java/com/dd/blog/global/security/CustomOAuth2UserService.java
@@ -2,7 +2,10 @@ package com.dd.blog.global.security;
 
 import com.dd.blog.domain.user.user.entity.User;
 import com.dd.blog.domain.user.user.entity.UserRole;
+import com.dd.blog.domain.user.user.entity.UserStatus;
 import com.dd.blog.domain.user.user.service.UserService;
+import com.dd.blog.global.exception.ApiException;
+import com.dd.blog.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -45,6 +48,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // 서비스 회원가입 또는 정보 업데이트
         User user = userService.joinOrUpdateOAuth2User(providerTypeCode, oauthId, email, nickname);
+
+        if (user.getStatus() == UserStatus.SUSPENDED) {
+
+            throw new ApiException(ErrorCode.ACCOUNT_SUSPENDED, "정지된 계정입니다. 관리자에게 문의하세요.");
+        }
 
         return new SecurityUser(
                 user.getId(),


### PR DESCRIPTION

### 1️⃣관련 이슈
이슈 링크 달아주세요. 

🔗
</br>#159</br>
.
### 2️⃣작업 내용
어떤 기능을 구현했는지 간단히 설명

✒️
</br>계정 정지 유저는 로그인 불가 구현</br>

.
### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [X] 로컬에서 테스트 완료 🧪🫧

</br>어떻게 테스트했는지 (경로, 사용 조건 등)

✒️
</br>직접 테스트</br>



