### PR TITLE
[fix] 유저 프로필 화면 - 좌측 사이드바 접근 시 다른 유저 프로필 화면처럼 보여지는 이슈("팔로우" 보임)

### DIFF
--- a/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
+++ b/be/src/main/java/com/dd/blog/domain/post/post/service/PostService.java
@@ -118,7 +118,12 @@ public class PostService {
         if (!combinedList.isEmpty()) {
             allImageUrls = combinedList.toArray(new String[0]);
         } else {
-            allImageUrls = null;
+            // 인증게시판(카테고리 ID 3)의 경우 이미지가 필수
+            if (categoryId == 3L) {
+                throw new IllegalArgumentException("인증게시판에는 이미지가 필수입니다.");
+            }
+            // 다른 게시판은 이미지 없이도 등록 가능 (빈 배열로 설정)
+            allImageUrls = new String[0];
         }
 
         Post post = Post.builder()

--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -9,6 +9,7 @@ import Post from "@/components/Post";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import { toast } from "react-hot-toast";
+import { useRouter } from "next/navigation";
 
 export interface Post {
   postId: number;
@@ -65,6 +66,8 @@ export default function Home() {
 
   // 마지막 요소 참조용
   const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const router = useRouter();
 
   const boardOptions = [
     { value: "0", label: "전체게시판" },
@@ -767,14 +770,14 @@ export default function Home() {
                       )}
                     </div>
                   </Link>
-                  <Link
-                    href={`/profile/${user.id}`}
+                  <button
+                    onClick={() => router.push("/profile/me")}
                     className="hover:text-pink-500 transition-colors"
                   >
                     <h3 className="text-lg font-bold text-gray-900">
                       @{user.nickname}
                     </h3>
-                  </Link>
+                  </button>
                   <div className="px-2 py-0.5 bg-yellow-100 rounded-full text-sm text-yellow-800 font-medium mb-3 mt-1">
                     {userLevel}
                   </div>


### PR DESCRIPTION
---
name: 🐞 Bugfix
about: 버그를 수정하는 PR 템플릿입니다.
title: "[FIX] 대상 - 버그 설명 및 해결 - #이슈번호"
labels: 🐞 bugfix
---

</br>

# 🐞 Bugfix PR

버그 수정 PR입니다. 

</br>

> ### 📝 PR 제목 규칙
> **❝ [FIX] 대상 - 버그 설명 및 해결 - #이슈번호 ❞**
</br>*( 예: ❛ 	[FIX] Login - 토큰 누락 오류 해결 - #25 ❜ )* 

✒️

</br></br>
---

### ✏️ 여기부터 써주시면 됩니다.
.
</br>.

### 1️⃣관련 이슈
이슈 링크 달아주세요. 

🔗 #162 
</br></br>
.
### 2️⃣버그 설명
어떤 문제가 있었는지

✒️메인페이지 왼쪽 프로필카드의 내 닉네임을 누르면 profile/me로 이동되는게 아니라 profile/[id]에 내 닉네임을 넣어서 넘겨지는 문제
링크 수정으로 해결
</br></br>

.
### 3️⃣수정 내역
어떻게 수정했는지
✒️

</br></br>
